### PR TITLE
Enforce pre-commit in CI, add first test, fix gitignored tests/ dir

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,16 @@
+version: 2
+updates:
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+
+  - package-ecosystem: "pre-commit"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,24 @@ on:
     branches: [ main ]
 
 jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e .[dev]
+
+      - name: Run pre-commit hooks
+        run: pre-commit run --all-files
+
   test:
     runs-on: ubuntu-latest
     strategy:
@@ -14,10 +32,10 @@ jobs:
         python-version: ["3.10", "3.11"]
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
 
@@ -25,3 +43,6 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install -e .[dev,docs]
+
+      - name: Run tests
+        run: pytest

--- a/.gitignore
+++ b/.gitignore
@@ -165,6 +165,5 @@ cython_debug/
 
 TODO.md
 docs/_build/
-tests/
 notebooks/exemple.ipynb
 notebooks/tutorial.ipynb

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,9 +2,19 @@
 # Voir https://pre-commit.com pour plus d'informations
 
 repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v6.0.0
+    hooks:
+      - id: trailing-whitespace
+      - id: end-of-file-fixer
+      - id: check-yaml
+      - id: check-toml
+      - id: check-added-large-files
+      - id: check-merge-conflict
+
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    # Mettez à jour 'rev' vers la dernière version de ruff-pre-commit si nécessaire
-    rev: v0.4.1
+    # Dependabot ("pre-commit" ecosystem) garde ce rev à jour automatiquement
+    rev: v0.16.1
     hooks:
       # Exécute le linter ruff et corrige automatiquement les problèmes simples
       - id: ruff

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -17,4 +17,3 @@ python:
       path: .
       extra_requirements:
         - docs
-

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -15,4 +15,3 @@ clean:
 
 html:
 	@$(SPHINXBUILD) -M html "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
-

--- a/docs/_autosummary/dstft.dstft.rst
+++ b/docs/_autosummary/dstft.dstft.rst
@@ -3,11 +3,10 @@ dstft.dstft
 
 .. automodule:: dstft.dstft
 
-   
+
    .. rubric:: Classes
 
    .. autosummary::
-   
+
       DSTFT
       WindowFn
-   

--- a/docs/_autosummary/dstft.rst
+++ b/docs/_autosummary/dstft.rst
@@ -3,7 +3,7 @@
 
 .. automodule:: dstft
 
-   
+
 .. rubric:: Modules
 
 .. autosummary::

--- a/docs/_autosummary/dstft.visualization.rst
+++ b/docs/_autosummary/dstft.visualization.rst
@@ -3,11 +3,10 @@ dstft.visualization
 
 .. automodule:: dstft.visualization
 
-   
+
    .. rubric:: Functions
 
    .. autosummary::
-   
+
       plot_spec
       plot_win_lengths
-   

--- a/docs/_autosummary/dstft.windows.rst
+++ b/docs/_autosummary/dstft.windows.rst
@@ -3,10 +3,9 @@ dstft.windows
 
 .. automodule:: dstft.windows
 
-   
+
    .. rubric:: Functions
 
    .. autosummary::
-   
+
       hann_window
-   

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -6,4 +6,3 @@ API reference
    :recursive:
 
    dstft
-

--- a/docs/citation.rst
+++ b/docs/citation.rst
@@ -50,4 +50,3 @@ Links
 - EUSIPCO (arXiv): https://arxiv.org/abs/2208.10886
 - ICASSP (arXiv): https://arxiv.org/abs/2308.02418
 - SSP Workshop (arXiv): https://arxiv.org/abs/2308.02421
-

--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -20,4 +20,3 @@ Quick example:
    dstft = DSTFT(n_fft=256, hop_length=64.0, win_length=256.0, window_mode="constant")
    dstft.initialize(x)
    spec, stft = dstft(x)
-

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -43,4 +43,3 @@ Install optional dependencies:
 .. code-block:: bash
 
    uv pip install -e ".[dev,docs]"
-

--- a/docs/notebooks/inverse.ipynb
+++ b/docs/notebooks/inverse.ipynb
@@ -365,7 +365,7 @@
     "\n",
     "win_time = dstft_time.win_length.detach().cpu()\n",
     "spec_learn_time, _ = dstft_time(x)\n",
-    "dstft_time.plot_spec(spec_learn_time, title='Optimized STFT (time)')\n",
+    "dstft_time.plot_spec(spec_learn_time, title=\"Optimized STFT (time)\")\n",
     "dstft_time.plot_win_lengths(title=\"Learned win_length over frames\")"
    ]
   },
@@ -455,7 +455,7 @@
     "    patience=patience,\n",
     ")\n",
     "\n",
-    "for epoch in range(epochs):\n",
+    "for _ in range(epochs):\n",
     "    optimizer.zero_grad(set_to_none=True)\n",
     "    spec, stft = dstft_tf(x)\n",
     "    loss = entropy_loss(spec)\n",
@@ -463,13 +463,12 @@
     "    optimizer.step()\n",
     "    scheduler.step(loss.detach())\n",
     "\n",
-    "\n",
     "    if optimizer.param_groups[0][\"lr\"] < threshold:\n",
     "        break\n",
     "\n",
     "win_time = dstft_tf.win_length.detach().cpu()\n",
     "spec_learn_time, _ = dstft_tf(x)\n",
-    "dstft_tf.plot_spec(spec_learn_time, title='Optimized STFT (time-frequency)')\n",
+    "dstft_tf.plot_spec(spec_learn_time, title=\"Optimized STFT (time-frequency)\")\n",
     "dstft_tf.plot_win_lengths(title=\"Learned win_length over frames\");"
    ]
   },

--- a/notebooks/inverse.ipynb
+++ b/notebooks/inverse.ipynb
@@ -365,7 +365,7 @@
     "\n",
     "win_time = dstft_time.win_length.detach().cpu()\n",
     "spec_learn_time, _ = dstft_time(x)\n",
-    "dstft_time.plot_spec(spec_learn_time, title='Optimized STFT (time)')\n",
+    "dstft_time.plot_spec(spec_learn_time, title=\"Optimized STFT (time)\")\n",
     "dstft_time.plot_win_lengths(title=\"Learned win_length over frames\")"
    ]
   },
@@ -455,7 +455,7 @@
     "    patience=patience,\n",
     ")\n",
     "\n",
-    "for epoch in range(epochs):\n",
+    "for _ in range(epochs):\n",
     "    optimizer.zero_grad(set_to_none=True)\n",
     "    spec, stft = dstft_tf(x)\n",
     "    loss = entropy_loss(spec)\n",
@@ -463,13 +463,12 @@
     "    optimizer.step()\n",
     "    scheduler.step(loss.detach())\n",
     "\n",
-    "\n",
     "    if optimizer.param_groups[0][\"lr\"] < threshold:\n",
     "        break\n",
     "\n",
     "win_time = dstft_tf.win_length.detach().cpu()\n",
     "spec_learn_time, _ = dstft_tf(x)\n",
-    "dstft_tf.plot_spec(spec_learn_time, title='Optimized STFT (time-frequency)')\n",
+    "dstft_tf.plot_spec(spec_learn_time, title=\"Optimized STFT (time-frequency)\")\n",
     "dstft_tf.plot_win_lengths(title=\"Learned win_length over frames\");"
    ]
   },

--- a/tests/test_dstft.py
+++ b/tests/test_dstft.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+
+import torch
+
+from dstft import DSTFT
+
+
+def test_forward_returns_spec_and_stft() -> None:
+    torch.manual_seed(0)
+    x = torch.randn(1, 1024)
+
+    dstft = DSTFT(
+        n_fft=256,
+        hop_length=64.0,
+        win_length=256.0,
+        window_mode="constant",
+    )
+    dstft.initialize(x)
+
+    spec, stft = dstft(x)
+
+    assert spec.shape[0] == 1
+    assert stft.shape[0] == 1
+    assert torch.isfinite(spec).all()
+    assert torch.isfinite(stft.abs()).all()


### PR DESCRIPTION
## Summary
- `pre-commit`: bump `ruff-pre-commit` to v0.16.1 (was v0.4.1, pinned since 2024) and add hygiene hooks from `pre-commit/pre-commit-hooks` (trailing whitespace, end-of-file, yaml/toml checks, large files, merge conflicts)
- `.gitignore`: remove the `tests/` entry — it was silently excluding the whole test suite even though `pyproject.toml`/`ruff` were already configured for it
- `.github/workflows/ci.yml`: the CI previously only ran `pip install`, neither lint nor tests. Added a `lint` job (`pre-commit run --all-files`) and a `pytest` step in the existing test matrix. Bumped `actions/checkout` and `actions/setup-python` to v4/v5
- `tests/test_dstft.py`: first test (smoke test on the README usage example)
- `.github/dependabot.yml`: weekly updates for `pip`, `github-actions`, and `pre-commit` ecosystems
- `notebooks/inverse.ipynb`, `docs/notebooks/inverse.ipynb`: fix an unused loop variable (ruff B007), aligned with the `for _ in range(...)` convention already used elsewhere in the same notebook

## Why
`pre-commit run --all-files` had never actually been run in CI, so drift had accumulated silently (stale ruff pin, missing hygiene hooks, a real lint error in the notebooks). The `.gitignore` bug meant no test could ever be committed despite the test tooling already being configured. This PR closes both gaps without touching the public API.

## Test plan
- [x] `pre-commit run --all-files` passes locally (verified idempotent on a second run)
- [x] `pytest` passes locally (1 test)
- [ ] Confirm both CI jobs (`lint`, `test`) are green on this PR in GitHub Actions

---
_Generated by [Claude Code](https://claude.ai/code/session_01KyjjDHc4vpTx6jDv1rWfC7)_