### PR TITLE
Add mypy (hook + config) and pytest-cov

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,4 +45,4 @@ jobs:
           pip install -e .[dev,docs]
 
       - name: Run tests
-        run: pytest
+        run: python -m pytest --cov=dstft --cov-report=term-missing

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -21,3 +21,17 @@ repos:
         args: [--fix, --exit-non-zero-on-fix]
       # Exécute le formateur ruff
       - id: ruff-format
+
+  - repo: local
+    hooks:
+      # Hook local (pas le mirror officiel) pour réutiliser l'environnement déjà
+      # installé (torch, matplotlib) au lieu d'un venv isolé qui devrait tout
+      # réinstaller. Ne couvre que src/dstft (voir [tool.mypy] dans pyproject.toml) :
+      # les tests ne sont volontairement pas typés (cf. discussion précédente).
+      - id: mypy
+        name: mypy
+        entry: python -m mypy
+        language: system
+        types: [python]
+        files: ^src/dstft/
+        pass_filenames: false

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,8 @@ dev = [
     "ruff>=0.1.0",
     "pytest>=7.0.0",
     "pre-commit>=3.0",
+    "mypy>=1.10",
+    "pytest-cov>=5.0",
 ]
 docs = [
     "sphinx>=7.0",
@@ -90,3 +92,10 @@ quote-style = "double"
 indent-style = "space"
 skip-magic-trailing-comma = false
 line-ending = "auto"
+
+[tool.mypy]
+python_version = "3.10"
+files = ["src/dstft"]
+warn_unused_configs = true
+warn_redundant_casts = true
+warn_unused_ignores = true

--- a/src/dstft/_core.py
+++ b/src/dstft/_core.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from collections.abc import Callable
 from math import pi
 
 import torch
@@ -581,12 +582,12 @@ def adstft_dft_adjoint(
 
 def cg_solve(
     *,
-    apply_mat: callable,
+    apply_mat: Callable[[torch.Tensor], torch.Tensor],
     b: torch.Tensor,
     x0: torch.Tensor | None = None,
     max_iter: int = 200,
     tol: float = 1e-10,
-    precond: callable | None = None,
+    precond: Callable[[torch.Tensor], torch.Tensor] | None = None,
 ) -> torch.Tensor:
     """Conjugate gradient solver for symmetric positive definite operators.
 

--- a/src/dstft/dstft.py
+++ b/src/dstft/dstft.py
@@ -381,6 +381,7 @@ class DSTFT(nn.Module):
             raise RuntimeError("DSTFT must be initialized before inverse")
         if self._init_signal_length is None:
             raise RuntimeError("DSTFT initialization metadata is missing")
+        signal_length = self._init_signal_length
         method = method.lower()
         if method == "auto":
             method = (
@@ -426,7 +427,7 @@ class DSTFT(nn.Module):
                 analysis_window=analysis_window,
                 n_fft=self.n_fft,
                 frame_positions=frame_positions,
-                signal_length=int(self._init_signal_length),
+                signal_length=signal_length,
                 eps=self.eps,
             )
 
@@ -436,7 +437,7 @@ class DSTFT(nn.Module):
                     analysis_window=analysis_window.to(stft.dtype),
                     n_fft=self.n_fft,
                     frame_positions=frame_positions,
-                    signal_length=int(self._init_signal_length),
+                    signal_length=signal_length,
                 )
                 return (num.real / den[None, :]).to(inv_dtype)
 
@@ -446,7 +447,7 @@ class DSTFT(nn.Module):
                 analysis_window=analysis_window.to(stft.dtype),
                 n_fft=self.n_fft,
                 frame_positions=frame_positions,
-                signal_length=int(self._init_signal_length),
+                signal_length=signal_length,
             ).real
 
             def apply_a(x_time: torch.Tensor) -> torch.Tensor:
@@ -469,7 +470,7 @@ class DSTFT(nn.Module):
                     analysis_window=analysis_window.to(y_stft.dtype),
                     n_fft=self.n_fft,
                     frame_positions=frame_positions,
-                    signal_length=int(self._init_signal_length),
+                    signal_length=signal_length,
                 ).real
 
             def apply_mat(x_time: torch.Tensor) -> torch.Tensor:
@@ -514,7 +515,7 @@ class DSTFT(nn.Module):
             analysis_window=analysis_window.to(
                 device=frames_td.device, dtype=frames_td.dtype
             ),
-            signal_length=int(self._init_signal_length),
+            signal_length=signal_length,
             eps=self.eps,
         )
 


### PR DESCRIPTION
## Summary
**B — mypy**
- `src/dstft/` was already well-typed (`TypeAlias`, `Protocol`, `Literal`); this locks it in for future changes so typing doesn't silently drift.
- `pyproject.toml`: `[tool.mypy]` scoped to `src/dstft` only — `tests/` intentionally stays unannotated (discussed separately: low ROI there vs. the public API).
- `.pre-commit-config.yaml`: local hook (`language: system`, `entry: python -m mypy`) instead of the official mirror, to reuse the already-installed torch/matplotlib rather than reinstalling them in an isolated venv. No separate CI step needed — the `lint` job already runs `pre-commit run --all-files`.
- Fixed what the first run actually found:
  - `_core.cg_solve`: `callable` was used as a type annotation instead of `typing.Callable` — cosmetic at runtime, but wrong.
  - `DSTFT.inverse`: a real mypy narrowing limitation across a nested closure (`apply_at`) on `self._init_signal_length`. Fixed by capturing the already None-checked value into a local `signal_length`, which also removed 4 redundant `int(...)` casts on the same value in that method.

**C — pytest-cov**
- Added as a dev dependency, wired into the CI test step (`--cov=dstft --cov-report=term-missing`) so coverage shows in every run.
- No badge/Codecov: coverage is ~38% today (1 test) — a badge would be noise before tests are expanded. Revisit once test coverage grows.
- `ci.yml`: switched `pytest` → `python -m pytest` for interpreter consistency with the `python -m mypy` hook.

## Test plan
- [x] `pre-commit run --all-files` passes locally (mypy hook included)
- [x] `python -m pytest --cov=dstft --cov-report=term-missing` passes locally
- [ ] Confirm CI (`lint`, `test 3.10`, `test 3.11`) is green on this PR

---
_Generated by [Claude Code](https://claude.ai/code/session_01KyjjDHc4vpTx6jDv1rWfC7)_