### PR TITLE
Expand test coverage to 86% (target was 50%)

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,15 @@
+from __future__ import annotations
+
+import matplotlib
+import pytest
+
+
+matplotlib.use("Agg")
+
+import matplotlib.pyplot as plt  # noqa: E402
+
+
+@pytest.fixture(autouse=True)
+def _close_figures():
+    yield
+    plt.close("all")

--- a/tests/test_dstft.py
+++ b/tests/test_dstft.py
@@ -1,8 +1,10 @@
 from __future__ import annotations
 
+import pytest
 import torch
 
 from dstft import DSTFT
+from dstft.dstft import HopMode, WindowMode
 
 
 def test_forward_returns_spec_and_stft() -> None:
@@ -23,3 +25,186 @@ def test_forward_returns_spec_and_stft() -> None:
     assert stft.shape[0] == 1
     assert torch.isfinite(spec).all()
     assert torch.isfinite(stft.abs()).all()
+
+
+# ---------------------------------------------------------------------------
+# Constructor validation
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("kwargs", "match"),
+    [
+        ({"n_fft": 0}, "n_fft must be positive"),
+        ({"n_fft": -1}, "n_fft must be positive"),
+        ({"hop_length": 0.0}, "hop_length must be positive"),
+        ({"win_length": 0.0}, "win_length must be positive"),
+        ({"magnitude_power": 0.0}, "magnitude_power must be positive"),
+        ({"eps": 0.0}, "eps must be positive"),
+    ],
+)
+def test_constructor_validates_parameters(kwargs: dict[str, float], match: str) -> None:
+    kwargs.setdefault("n_fft", 64)
+    with pytest.raises(ValueError, match=match):
+        DSTFT(**kwargs)
+
+
+def test_dstft_rejects_unknown_window_string() -> None:
+    with pytest.raises(ValueError, match="Unknown window"):
+        DSTFT(n_fft=64, window="not-hann")
+
+
+def test_dstft_rejects_invalid_window_type() -> None:
+    with pytest.raises(TypeError, match="window must be"):
+        DSTFT(n_fft=64, window=123)  # type: ignore[arg-type]
+
+
+def test_dstft_accepts_custom_window_callable() -> None:
+    def rectangular_window(
+        *,
+        n_fft: int,
+        frames: int,
+        device: torch.device,
+        dtype: torch.dtype,
+        **_: object,
+    ) -> torch.Tensor:
+        return torch.ones(1, frames, n_fft, device=device, dtype=dtype)
+
+    torch.manual_seed(0)
+    x = torch.randn(1, 256)
+    dstft = DSTFT(
+        n_fft=64, hop_length=16.0, window=rectangular_window, window_mode="time"
+    )
+    dstft.initialize(x)
+    spec, _ = dstft(x)
+    assert torch.isfinite(spec).all()
+
+
+# ---------------------------------------------------------------------------
+# forward() across window_mode / hop_mode
+# ---------------------------------------------------------------------------
+
+WINDOW_MODES: list[WindowMode] = [
+    "fixed",
+    "constant",
+    "time",
+    "frequency",
+    "time-frequency",
+]
+
+
+@pytest.mark.parametrize("window_mode", WINDOW_MODES)
+def test_forward_across_window_modes(window_mode: WindowMode) -> None:
+    torch.manual_seed(0)
+    x = torch.randn(2, 256)
+    dstft = DSTFT(n_fft=64, win_length=48.0, hop_length=16.0, window_mode=window_mode)
+    dstft.initialize(x)
+
+    spec, stft = dstft(x)
+
+    assert spec.shape == stft.shape
+    assert spec.shape[0] == 2
+    assert torch.isfinite(spec).all()
+    assert torch.isfinite(stft.abs()).all()
+
+
+HOP_MODES: list[HopMode] = ["fixed", "constant", "time"]
+
+
+@pytest.mark.parametrize("hop_mode", HOP_MODES)
+def test_forward_across_hop_modes(hop_mode: HopMode) -> None:
+    torch.manual_seed(0)
+    x = torch.randn(1, 256)
+    dstft = DSTFT(n_fft=64, win_length=48.0, hop_length=16.0, hop_mode=hop_mode)
+    dstft.initialize(x)
+
+    spec, _ = dstft(x)
+
+    assert torch.isfinite(spec).all()
+
+
+# ---------------------------------------------------------------------------
+# forward() input validation
+# ---------------------------------------------------------------------------
+
+
+def test_forward_rejects_non_tensor_input() -> None:
+    dstft = DSTFT(n_fft=64)
+    with pytest.raises(TypeError, match="must be a torch.Tensor"):
+        dstft([1.0, 2.0])  # type: ignore[arg-type]
+
+
+def test_forward_rejects_wrong_ndim() -> None:
+    dstft = DSTFT(n_fft=64)
+    with pytest.raises(ValueError, match=r"shape \[batch, time\]"):
+        dstft(torch.randn(64))
+
+
+def test_forward_before_initialize_raises() -> None:
+    dstft = DSTFT(n_fft=64)
+    with pytest.raises(RuntimeError, match="must be initialized"):
+        dstft(torch.randn(1, 256))
+
+
+# ---------------------------------------------------------------------------
+# initialize()
+# ---------------------------------------------------------------------------
+
+
+def test_initialize_rejects_signal_shorter_than_n_fft() -> None:
+    dstft = DSTFT(n_fft=256)
+    with pytest.raises(ValueError, match="must be >= n_fft"):
+        dstft.initialize(torch.randn(1, 64))
+
+
+def test_initialize_is_idempotent_for_same_signal_length() -> None:
+    dstft = DSTFT(n_fft=64)
+    dstft.initialize(torch.randn(1, 256))
+    dstft.initialize(torch.randn(1, 256))  # same length, different values: no error
+
+
+def test_initialize_rejects_different_signal_length() -> None:
+    dstft = DSTFT(n_fft=64)
+    dstft.initialize(torch.randn(1, 256))
+    with pytest.raises(RuntimeError, match="already initialized with signal_length"):
+        dstft.initialize(torch.randn(1, 128))
+
+
+def test_initialize_rejects_different_dtype() -> None:
+    dstft = DSTFT(n_fft=64)
+    dstft.initialize(torch.randn(1, 256, dtype=torch.float32))
+    with pytest.raises(RuntimeError, match="already initialized with dtype"):
+        dstft.initialize(torch.randn(1, 256, dtype=torch.float64))
+
+
+# ---------------------------------------------------------------------------
+# frame_centers() / win_length & hop_length properties
+# ---------------------------------------------------------------------------
+
+
+def test_frame_centers_before_initialize_raises() -> None:
+    dstft = DSTFT(n_fft=64)
+    with pytest.raises(
+        RuntimeError, match="must be initialized before reading frame centers"
+    ):
+        dstft.frame_centers()
+
+
+def test_frame_centers_with_time_hop_mode() -> None:
+    dstft = DSTFT(n_fft=64, hop_mode="time")
+    dstft.initialize(torch.randn(1, 256))
+    centers = dstft.frame_centers()
+    assert centers.ndim == 1
+    assert torch.isfinite(centers).all()
+
+
+def test_win_length_and_hop_length_properties_before_and_after_init() -> None:
+    dstft = DSTFT(n_fft=64, win_length=48.0, hop_length=16.0)
+
+    assert torch.isfinite(dstft.win_length).all()
+    assert torch.isfinite(dstft.hop_length).all()
+
+    dstft.initialize(torch.randn(1, 256))
+
+    assert torch.isfinite(dstft.win_length).all()
+    assert torch.isfinite(dstft.hop_length).all()

--- a/tests/test_inverse.py
+++ b/tests/test_inverse.py
@@ -1,0 +1,75 @@
+from __future__ import annotations
+
+import pytest
+import torch
+
+from dstft import DSTFT
+from dstft.dstft import WindowMode
+
+
+def _make_initialized(
+    window_mode: WindowMode,
+    *,
+    n_fft: int = 64,
+    win_length: float = 48.0,
+    hop_length: float = 16.0,
+    signal_length: int = 256,
+) -> tuple[DSTFT, torch.Tensor, torch.Tensor]:
+    torch.manual_seed(0)
+    x = torch.randn(1, signal_length)
+    dstft = DSTFT(
+        n_fft=n_fft,
+        win_length=win_length,
+        hop_length=hop_length,
+        window_mode=window_mode,
+    )
+    dstft.initialize(x)
+    _, stft = dstft(x)
+    return dstft, x, stft
+
+
+@pytest.mark.parametrize("window_mode", ["fixed", "constant", "time"])
+def test_inverse_fft_backend_reconstructs(window_mode: WindowMode) -> None:
+    dstft, x, stft = _make_initialized(window_mode)
+    x_hat = dstft.inverse(stft)
+    assert x_hat.shape == x.shape
+    assert torch.isfinite(x_hat).all()
+
+
+@pytest.mark.parametrize("method", ["auto", "wola", "cg"])
+def test_inverse_dft_backend_methods(method: str) -> None:
+    dstft, x, stft = _make_initialized("time-frequency")
+    x_hat = dstft.inverse(stft, method=method, cg_max_iter=5)
+    assert x_hat.shape == x.shape
+    assert torch.isfinite(x_hat).all()
+
+
+def test_inverse_rejects_non_tensor() -> None:
+    dstft, _, _ = _make_initialized("constant")
+    with pytest.raises(TypeError, match="must be a torch.Tensor"):
+        dstft.inverse([1, 2, 3])  # type: ignore[arg-type]
+
+
+def test_inverse_rejects_wrong_ndim() -> None:
+    dstft, _, _ = _make_initialized("constant")
+    with pytest.raises(ValueError, match=r"shape \[batch, freq, frames\]"):
+        dstft.inverse(torch.randn(4, 4))
+
+
+def test_inverse_before_initialize_raises() -> None:
+    dstft = DSTFT(n_fft=64)
+    with pytest.raises(RuntimeError, match="must be initialized"):
+        dstft.inverse(torch.randn(1, 33, 10, dtype=torch.cfloat))
+
+
+def test_inverse_rejects_unknown_method() -> None:
+    dstft, _, stft = _make_initialized("constant")
+    with pytest.raises(ValueError, match="Unknown inverse method"):
+        dstft.inverse(stft, method="nope")
+
+
+def test_inverse_rejects_wrong_freq_dim() -> None:
+    dstft, _, stft = _make_initialized("constant")
+    bad_stft = stft[:, :-1, :]  # drop one frequency bin
+    with pytest.raises(ValueError, match="freq dimension"):
+        dstft.inverse(bad_stft)

--- a/tests/test_visualization.py
+++ b/tests/test_visualization.py
@@ -1,0 +1,71 @@
+from __future__ import annotations
+
+import matplotlib.pyplot as plt
+import pytest
+import torch
+
+from dstft import DSTFT
+from dstft.visualization import plot_spec, plot_win_lengths
+
+
+def test_plot_spec_returns_figure_and_axis() -> None:
+    spec = torch.rand(1, 8, 10)
+    fig, ax = plot_spec(spec, show=False)
+    assert fig is not None
+    assert ax is not None
+
+
+def test_plot_spec_rejects_wrong_ndim() -> None:
+    with pytest.raises(ValueError, match=r"shape \[batch, freq, frames\]"):
+        plot_spec(torch.rand(8, 10), show=False)
+
+
+def test_plot_spec_reuses_provided_axis() -> None:
+    _, ax = plt.subplots()
+    spec = torch.rand(1, 8, 10)
+    _, returned_ax = plot_spec(spec, ax=ax, colorbar=False, title="t", show=False)
+    assert returned_ax is ax
+
+
+@pytest.mark.parametrize(
+    "win_length",
+    [
+        256.0,
+        torch.tensor(256.0),
+        torch.full((5,), 256.0),
+        torch.full((3, 5), 256.0),
+    ],
+)
+def test_plot_win_lengths_shape_variants(
+    win_length: float | torch.Tensor,
+) -> None:
+    fig, ax = plot_win_lengths(win_length, show=False)
+    assert fig is not None
+    assert ax is not None
+
+
+def test_plot_win_lengths_rejects_bad_ndim() -> None:
+    with pytest.raises(ValueError, match="scalar, 1D"):
+        plot_win_lengths(torch.rand(2, 3, 4), show=False)
+
+
+def test_dstft_plot_wrappers() -> None:
+    torch.manual_seed(0)
+    x = torch.randn(1, 256)
+    dstft = DSTFT(n_fft=64, win_length=48.0, hop_length=16.0, window_mode="constant")
+    dstft.initialize(x)
+    spec, _ = dstft(x)
+
+    fig1, ax1 = dstft.plot_spec(spec, show=False)
+    fig2, ax2 = dstft.plot_win_lengths(show=False)
+
+    assert fig1 is not None
+    assert ax1 is not None
+    assert fig2 is not None
+    assert ax2 is not None
+
+
+def test_plot_win_lengths_before_initialize_raises() -> None:
+    dstft = DSTFT(n_fft=64)
+    with pytest.raises(RuntimeError, match="must be initialized before plotting"):
+        dstft.plot_win_lengths(show=False)

--- a/tests/test_windows.py
+++ b/tests/test_windows.py
@@ -1,0 +1,86 @@
+from __future__ import annotations
+
+import pytest
+import torch
+
+from dstft.windows import hann_window
+
+
+def _call(
+    theta: torch.Tensor,
+    *,
+    freq_bins: int = 1,
+    frames: int = 4,
+    normalization: str | None = None,
+) -> torch.Tensor:
+    idx_frac = torch.zeros(frames)
+    return hann_window(
+        n_fft=16,
+        theta=theta,
+        idx_frac=idx_frac,
+        freq_bins=freq_bins,
+        frames=frames,
+        device=torch.device("cpu"),
+        dtype=torch.float32,
+        normalization=normalization,
+    )
+
+
+def test_hann_window_rejects_non_2d_theta() -> None:
+    with pytest.raises(ValueError, match="theta must be 2D"):
+        _call(torch.tensor(8.0))
+
+
+def test_hann_window_rejects_bad_freq_dim() -> None:
+    with pytest.raises(ValueError, match="first dimension"):
+        _call(torch.full((3, 1), 8.0), freq_bins=5)
+
+
+def test_hann_window_rejects_bad_time_dim() -> None:
+    with pytest.raises(ValueError, match="second dimension"):
+        _call(torch.full((1, 3), 8.0), frames=4)
+
+
+def test_hann_window_rejects_frame_idx_frac_mismatch() -> None:
+    with pytest.raises(ValueError, match="frames must match idx_frac"):
+        hann_window(
+            n_fft=16,
+            theta=torch.full((1, 4), 8.0),
+            idx_frac=torch.zeros(2),
+            freq_bins=1,
+            frames=4,
+            device=torch.device("cpu"),
+            dtype=torch.float32,
+            normalization=None,
+        )
+
+
+@pytest.mark.parametrize("normalization", [None, "unit", "paper", "contract"])
+def test_hann_window_normalization_modes(normalization: str | None) -> None:
+    w = _call(torch.full((1, 1), 8.0), normalization=normalization)
+    assert torch.isfinite(w).all()
+    if normalization == "unit":
+        assert torch.allclose(w.sum(dim=-1), torch.ones(1, 1), atol=1e-5)
+
+
+def test_hann_window_paper_normalization_on_frequency_shape() -> None:
+    # f_dim > 1, t_dim == 1: exercises the "frequency"/"time-frequency" branch
+    # of the paper/contract scaling, distinct from the scalar/time branch.
+    w = _call(torch.full((3, 1), 8.0), freq_bins=3, frames=4, normalization="paper")
+    assert torch.isfinite(w).all()
+
+
+def test_hann_window_rejects_unknown_normalization() -> None:
+    with pytest.raises(ValueError, match="Unknown normalization"):
+        _call(torch.full((1, 1), 8.0), normalization="bogus")
+
+
+@pytest.mark.parametrize(
+    ("f_dim", "t_dim"),
+    [(1, 1), (1, 4), (3, 1), (3, 4)],
+)
+def test_hann_window_shape_variants(f_dim: int, t_dim: int) -> None:
+    theta = torch.full((f_dim, t_dim), 8.0)
+    w = _call(theta, freq_bins=3, frames=4)
+    assert torch.isfinite(w).all()
+    assert w.shape[-1] == 16


### PR DESCRIPTION
## Summary

Stacked on #8 (mypy + pytest-cov), so this diff is only the new tests — base will auto-retarget to `main` once #8 merges.

Adds tests across all the previously-untested surfaces, organized by theme:
- `tests/test_dstft.py`: constructor validation, all 5 `window_mode` and 3 `hop_mode` combinations, custom window callables, `forward()`/`initialize()` input validation and state errors, `frame_centers()`, `win_length`/`hop_length` properties.
- `tests/test_inverse.py`: FFT-backend inverse (fixed/constant/time) and DFT-backend inverse (wola/cg/auto methods), plus input validation.
- `tests/test_windows.py`: `hann_window`'s shape validation and all 4 scalar/time/frequency/time-frequency branches, all 4 normalization modes.
- `tests/test_visualization.py`: `plot_spec`/`plot_win_lengths` shape handling and the `DSTFT.plot_*` convenience wrappers.
- `tests/conftest.py`: forces the `Agg` matplotlib backend and closes figures after each test, so plotting tests run headless in CI.

**Result: 63 tests, 86% line coverage** (was 38% with 1 test — target was 50%).

Remaining gaps are mostly defensive internal-invariant checks not reachable through the public API (e.g. `_validate_parameter_shapes`) and a CUDA device-mismatch branch that can't be exercised on CPU-only CI.

## Test plan
- [x] `python -m pytest --cov=dstft --cov-report=term-missing` — 63 passed, 86% coverage
- [x] `pre-commit run --all-files` passes locally (mypy included)
- [ ] Confirm CI is green on this PR

---
_Generated by [Claude Code](https://claude.ai/code/session_01KyjjDHc4vpTx6jDv1rWfC7)_