### PR TITLE
Derive package version from git tags via setuptools-scm

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,21 @@ This project is licensed under the terms of the MIT License. See the
 Contributions are welcome! Please open issues or pull requests for bug fixes,
 improvements, or new features.
 
+## Releasing
+
+The package version is derived automatically from git tags (via
+`setuptools-scm`) — it is never edited by hand in `pyproject.toml`. To cut a
+release:
+
+```bash
+git tag v3.0.1
+git push origin v3.0.1
+```
+
+Then build and publish as usual (`python -m build && twine upload dist/*`).
+A tag on a commit with no uncommitted local changes produces an exact version
+(`3.0.1`); any other commit gets an automatic `.devN+g<hash>` suffix.
+
 ## Citation
 
 Please cite this repository if you use it in your scientific work:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,10 +1,10 @@
 [build-system]
-requires = ["setuptools>=68", "wheel"]
+requires = ["setuptools>=68", "setuptools-scm>=8", "wheel"]
 build-backend = "setuptools.build_meta"
 
 [project]
 name = "dstft"
-version = "3.0.0"
+dynamic = ["version"]
 authors = [{ name = "Maxime Leiber" }]
 description = "Differentiable Short-Time Fourier Transform (DSTFT) for PyTorch"
 readme = { file = "README.md", content-type = "text/markdown" }
@@ -47,6 +47,15 @@ package-dir = { "" = "src" }
 
 [tool.setuptools.packages.find]
 where = ["src"]
+
+[tool.setuptools_scm]
+# Version comes from the nearest git tag (e.g. tag `v3.0.1` -> version
+# "3.0.1"; commits after a tag get an automatic dev suffix). No tag has
+# been created yet in this repo, so `fallback_version` keeps builds
+# working (matching the version currently published on PyPI) until the
+# first `vX.Y.Z` tag exists.
+fallback_version = "3.0.0"
+tag_regex = "^v(?P<version>\\d+\\.\\d+\\.\\d+)$"
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]

--- a/src/dstft/__init__.py
+++ b/src/dstft/__init__.py
@@ -3,8 +3,15 @@
 The public API is the `DSTFT` class.
 """
 
+from importlib.metadata import PackageNotFoundError, version
+
 from .dstft import DSTFT
 from .visualization import plot_spec, plot_win_lengths
 
 
-__all__ = ["DSTFT", "plot_spec", "plot_win_lengths"]
+try:
+    __version__ = version("dstft")
+except PackageNotFoundError:  # pragma: no cover - package not installed
+    __version__ = "0.0.0+unknown"
+
+__all__ = ["DSTFT", "__version__", "plot_spec", "plot_win_lengths"]

--- a/tests/test_dstft.py
+++ b/tests/test_dstft.py
@@ -3,8 +3,14 @@ from __future__ import annotations
 import pytest
 import torch
 
+import dstft
 from dstft import DSTFT
 from dstft.dstft import HopMode, WindowMode
+
+
+def test_version_is_exposed() -> None:
+    assert isinstance(dstft.__version__, str)
+    assert dstft.__version__ != ""
 
 
 def test_forward_returns_spec_and_stft() -> None:


### PR DESCRIPTION
## Summary

Version was a hardcoded string in `pyproject.toml`, manually edited before each release with no automated check that it was actually bumped or that it matched the git tag used to publish it.

- `pyproject.toml`: version is now `dynamic`, computed by `setuptools-scm` from the nearest `vX.Y.Z` git tag (+ automatic dev suffix for commits past a tag, or a dirty working tree). No tag exists yet in this repo, so `fallback_version = "3.0.0"` keeps builds working (matching what's currently on PyPI) until the first tag is created.
- `src/dstft/__init__.py`: expose `dstft.__version__` at runtime via `importlib.metadata`, the standard way to read it back once installed.
- `README.md`: document the new tag-based release workflow.

Verified locally: computes a sensible dev version with no tags (`3.0.1.dev53+g<hash>`), and an exact `3.0.0` from a `v3.0.0` tag on a clean tree (tested with a local, unpushed tag, then removed).

**Not included here** (needs your decision, see chat): actually auto-publishing to PyPI when a tag is pushed. This PR only makes the version number automatic — it does not touch how/when you publish.

## Test plan
- [x] `pip install -e .` computes a version from git (dev-version without a tag; exact version with a clean tag — tested locally)
- [x] `python -m pytest` — 64 passed (added a smoke test for `dstft.__version__`)
- [x] `pre-commit run --all-files` passes locally
- [ ] Confirm CI is green on this PR

---
_Generated by [Claude Code](https://claude.ai/code/session_01KyjjDHc4vpTx6jDv1rWfC7)_