### PR TITLE
Add manual RepoAgent trial workflow (workflow_dispatch only)

### DIFF
--- a/.github/workflows/repoagent-trial.yml
+++ b/.github/workflows/repoagent-trial.yml
@@ -1,0 +1,43 @@
+name: RepoAgent trial
+
+# Manual trigger only, on purpose: we're validating that an API key/model
+# works and reviewing the generated docs' quality before deciding whether
+# to wire RepoAgent into pre-commit/CI for real (see TODO.md [+repoagent-key]).
+on:
+  workflow_dispatch: {}
+
+jobs:
+  trial:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install RepoAgent
+        run: |
+          python -m pip install --upgrade pip
+          pip install repoagent
+
+      - name: Run RepoAgent
+        env:
+          OPENAI_API_KEY: ${{ secrets.REPOAGENT_API_KEY }}
+        run: |
+          repoagent run \
+            --target-repo-path . \
+            --language English \
+            --model "${{ vars.REPOAGENT_MODEL || 'gpt-4o-mini' }}" \
+            --base-url "${{ vars.REPOAGENT_BASE_URL || 'https://api.openai.com/v1' }}" \
+            --print-hierarchy
+
+      - name: Upload generated docs for review
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: repoagent-markdown-docs
+          path: markdown_docs
+          retention-days: 7
+          if-no-files-found: warn

--- a/.github/workflows/repoagent-trial.yml
+++ b/.github/workflows/repoagent-trial.yml
@@ -24,13 +24,15 @@ jobs:
 
       - name: Run RepoAgent
         env:
-          OPENAI_API_KEY: ${{ secrets.REPOAGENT_API_KEY }}
+          # Gemini's OpenAI-compatible endpoint: repoagent (built on the
+          # OpenAI SDK) just needs an OpenAI-shaped API key + base_url.
+          OPENAI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
         run: |
           repoagent run \
             --target-repo-path . \
             --language English \
-            --model "${{ vars.REPOAGENT_MODEL || 'gpt-4o-mini' }}" \
-            --base-url "${{ vars.REPOAGENT_BASE_URL || 'https://api.openai.com/v1' }}" \
+            --model "${{ vars.REPOAGENT_MODEL || 'gemini-2.5-flash' }}" \
+            --base-url "${{ vars.REPOAGENT_BASE_URL || 'https://generativelanguage.googleapis.com/v1beta/openai/' }}" \
             --print-hierarchy
 
       - name: Upload generated docs for review


### PR DESCRIPTION
## Summary

Manual-trigger-only workflow (`workflow_dispatch`) to validate an LLM key/model against RepoAgent before deciding whether to wire it into pre-commit/CI for real. Does nothing automatically — GitHub only allows dispatching a `workflow_dispatch` workflow once it exists on the default branch, hence this PR.

- Reads the key from the `GEMINI_API_KEY` repo secret (never exposed in logs or to me).
- Points at Gemini's OpenAI-compatible endpoint (`https://generativelanguage.googleapis.com/v1beta/openai/`), model `gemini-2.5-flash` by default — both overridable via repo variables (`REPOAGENT_BASE_URL`, `REPOAGENT_MODEL`) without touching the workflow.
- Uploads the generated `markdown_docs/` as an artifact for review, doesn't commit anything back to the repo.

## Test plan
- [ ] Merge, then manually dispatch the workflow and confirm RepoAgent runs successfully against this repo with the configured key

---
_Generated by [Claude Code](https://claude.ai/code/session_01KyjjDHc4vpTx6jDv1rWfC7)_