### PR TITLE
Add PyPI publish workflow (tag-triggered, Trusted Publishing) and trim sdist

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,56 @@
+name: Publish to PyPI
+
+# Triggered by pushing a `vX.Y.Z` tag (see README "Releasing"). Uses PyPI
+# Trusted Publishing (OIDC) — no API token/secret involved. Requires a
+# one-time setup on pypi.org: Settings -> Publishing -> Add a pending
+# publisher, pointing at this repo, this workflow file, and the "pypi"
+# environment below (the environment name must match exactly).
+on:
+  push:
+    tags:
+      - "v*.*.*"
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          # setuptools-scm needs the full history and tags to compute the
+          # version; a shallow checkout would silently fall back to
+          # fallback_version.
+          fetch-depth: 0
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Build sdist and wheel
+        run: |
+          python -m pip install --upgrade pip build
+          python -m build
+
+      - name: Check the version that was actually built
+        run: |
+          python -m pip install --quiet twine
+          python -m twine check dist/*
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: dist
+          path: dist/
+
+  publish:
+    needs: build
+    runs-on: ubuntu-latest
+    environment: pypi
+    permissions:
+      id-token: write # required for PyPI Trusted Publishing
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: dist/
+
+      - uses: pypa/gh-action-pypi-publish@release/v1

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,10 @@
+# setuptools-scm's sdist file-finder includes every git-tracked file by
+# default, which pulled in the whole repo (docs assets, notebooks, CI
+# configs) - ~8.4 MB for a package that only needs src/, tests/, LICENSE,
+# and README.md to install and run.
+prune docs
+prune notebooks
+prune .github
+exclude .readthedocs.yaml
+exclude .pre-commit-config.yaml
+exclude Makefile


### PR DESCRIPTION
## Summary

- `.github/workflows/publish.yml`: triggers on `vX.Y.Z` tag push, builds with setuptools-scm (`fetch-depth: 0`, needed for it to see tags), publishes via `pypa/gh-action-pypi-publish` using **PyPI Trusted Publishing** (OIDC) — no API token/secret involved. **Needs a one-time setup on pypi.org first** (Settings → Publishing → Add a pending publisher, pointing at this repo/workflow/the `pypi` environment) before it can actually succeed — tracked in `TODO.md` `[+pypi]`.
- `MANIFEST.in`: setuptools-scm's sdist file-finder defaults to including every git-tracked file, which pulled in the *entire repo* — `docs/_static/opt.gif` (4.6 MB) and two copies of `notebooks/inverse.ipynb` (2.5 MB each) — into what should be a small package. Trimmed the sdist from ~8.4 MB to ~28 KB.

Verified locally with a local, unpushed `v3.0.0` tag: `python -m build` + `twine check dist/*` both pass, correct version computed, correct trimmed file list.

## Test plan
- [x] `python -m build` + `twine check dist/*` — pass, sdist trimmed from 8.4 MB to 28 KB
- [x] `python -m pytest` — 64 passed
- [ ] Confirm CI is green on this PR
- [ ] After merge: tag `v3.0.0`, confirm the publish workflow runs (will fail until the pypi.org trusted-publisher step is done)

---
_Generated by [Claude Code](https://claude.ai/code/session_01KyjjDHc4vpTx6jDv1rWfC7)_