### PR TITLE
Pass CODECOV_TOKEN to Codecov upload

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,7 +52,8 @@ jobs:
         uses: codecov/codecov-action@v7
         with:
           files: ./coverage.xml
-          fail_ci_if_error: false
+          token: ${{ secrets.CODECOV_TOKEN }}
+          fail_ci_if_error: true
 
   docs:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- The `test` job's Codecov upload was failing server-side (`Token required - not valid tokenless upload`), silently hidden by `fail_ci_if_error: false`.
- Now that `CODECOV_TOKEN` exists as a repo secret, pass it to `codecov/codecov-action` and flip `fail_ci_if_error` to `true` so a real upload failure shows up as red CI instead of being masked.

## Test plan
- [ ] CI `test (3.11)` job succeeds and the Codecov upload step actually uploads (check the run logs for a report URL instead of the tokenless-rejection message)
- [ ] Codecov badge on the README shows a real percentage instead of "unknown"

---
_Generated by [Claude Code](https://claude.ai/code/session_01KyjjDHc4vpTx6jDv1rWfC7)_