### PR TITLE
Add markdown_docs/: RepoAgent-style codebase documentation

### DIFF
--- a/markdown_docs/src/dstft/__init__.md
+++ b/markdown_docs/src/dstft/__init__.md
@@ -1,0 +1,35 @@
+# `dstft/__init__.py`
+
+The package's public entry point. This file's only job is to decide what
+`import dstft` actually exposes — it contains no logic of its own.
+
+## What it exports
+
+```python
+__all__ = ["DSTFT", "__version__", "plot_spec", "plot_win_lengths"]
+```
+
+- **`DSTFT`** — re-exported from `dstft.dstft`. This is the one class users
+  are expected to instantiate; see `dstft.md`.
+- **`plot_spec`, `plot_win_lengths`** — re-exported from `dstft.visualization`,
+  so `dstft.plot_spec(...)` works without reaching into the submodule. The
+  same two functions are also available as bound methods on a `DSTFT`
+  instance (`DSTFT.plot_spec`, `DSTFT.plot_win_lengths`) for convenience.
+- **`__version__`** — resolved at import time via
+  `importlib.metadata.version("dstft")`, i.e. from the installed package's
+  metadata rather than a hardcoded string in the source. This is what makes
+  the version follow the git tag automatically (see `[tool.setuptools_scm]`
+  in `pyproject.toml`) instead of needing to be bumped by hand in two places.
+  If the package isn't installed (e.g. running from a raw source checkout
+  without `pip install -e .`), resolution raises `PackageNotFoundError`,
+  which is caught and falls back to the literal string `"0.0.0+unknown"`
+  rather than crashing on import.
+
+## Why this matters for the public API surface
+
+Anything not listed in `__all__` (and not one of these four names) is
+internal, even if it's technically importable with a longer dotted path —
+`dstft._core`, `dstft.windows`, and the private `_`-prefixed attributes on
+`DSTFT` are implementation details that can change without a semver-major
+bump. If you find yourself importing from `dstft._core` directly, that's a
+signal the public `DSTFT` API is missing something you need.

--- a/markdown_docs/src/dstft/_core.md
+++ b/markdown_docs/src/dstft/_core.md
@@ -1,0 +1,149 @@
+# `dstft/_core.py`
+
+The math kernels behind `DSTFT`. Everything here is a free function operating
+on plain tensors — no class, no stored state, nothing hidden. `dstft.py`
+holds the configuration and validation; this file is where the actual
+transform is computed. Two small module-level caches
+(`_FFT_FORWARD_CACHE`, `_DFT_TWIDDLE_CACHE`, keyed by shape/device/dtype)
+memoize tensors that are expensive to rebuild but never change for a given
+configuration (a bin-index arange, and a DFT twiddle-factor matrix).
+
+## The floor/frac convention (the idea everything else builds on)
+
+A recurring pattern through this whole file: a **frame center** `t_n` can be
+any real number, not just an integer sample index. Every function that needs
+one splits it into `idx_floor = floor(t_n)` (used for actual array indexing —
+you can't index an array at a fractional position) and `idx_frac = t_n -
+idx_floor` (used downstream: to continuously shift the analysis window in
+`windows.hann_window`, and to apply a frequency-domain phase-correction
+factor so the *effective* window is still centered at the true `t_n`, not
+just at `idx_floor`). This split is what the module docstrings across this
+file refer to as "paper Eq. (25)".
+
+## Frame positions and extraction
+
+### `compute_frame_positions_fixed_hop(*, signal_length, n_fft, hop_length, device, dtype) -> Tensor[frames]`
+
+Computes evenly-spaced frame centers for the common case of a constant hop:
+`t_n = n * hop_length` for `n = 0, 1, ..., num_frames - 1`, where
+`num_frames = 1 + floor(signal_length / hop_length)` (the `+1` and `floor`
+together are what the code calls the "cover" policy — enough frames to span
+the whole signal, even if the last one or two extend past its end, at which
+point they're implicitly zero-padded rather than clipped). `hop_length` can
+be a plain float or itself a tensor (so this composes with a learnable
+scalar hop length), but the *count* of frames is computed from a detached
+value — the number of frames is a **shape**, and shapes can't depend on a
+tensor that requires gradients.
+
+### `unfold_floor_frac(*, x, frame_positions, n_fft) -> (frames, idx_floor, idx_frac)`
+
+Given a batch of signals `x: [batch, time]` and a set of frame centers,
+extracts one length-`n_fft` window of raw samples around each center:
+`k ∈ {-n_fft//2, ..., n_fft//2 - 1}` relative to `floor(t_n)`. Any sample
+index that falls outside `[0, signal_length)` — i.e. a frame near the
+start/end of the signal — is replaced with `0` via a boolean mask rather than
+actually padding the input tensor (`torch.where(valid, gathered, 0)`), which
+is what makes the "implicit zero-padding" mentioned throughout this file
+implicit: there is no padded copy of `x` anywhere, just a validity mask
+applied at gather time.
+
+## Forward transform: two backends
+
+### `fdstft_fft_forward(*, frames, analysis_window, n_fft, idx_frac, idx_floor, fft_norm=None) -> stft[batch, freq, frames]`
+
+The fast path, used whenever the window is at most time-varying (not
+frequency-varying). Multiplies each extracted frame by its window
+(broadcastable — the same window can be shared across all frames, or vary
+per frame), runs a single batched `torch.fft.rfft` over all
+`batch * num_frames` windowed frames at once, then applies the phase
+correction factor `exp(-j·2π·floor(t_n)·m / n_fft)` per frequency bin `m` to
+account for the frame having actually been centered at the fractional `t_n`
+and not at `floor(t_n)`. Because this is a real FFT of a real input, one
+`rfft` call handles every frame — this is the reason a *frequency-varying*
+window can't use this path: `rfft` can't apply a different window per output
+bin.
+
+### `adstft_dft_forward(*, frames, analysis_window, n_fft, idx_frac, idx_floor) -> stft[batch, freq_bins, frames]`
+
+The general path, used when the window varies across frequency (`"frequency"`
+or `"time-frequency"` mode). Since each frequency bin can have its own
+window, it's no longer possible to reuse a single FFT across bins, so this
+function instead: (1) multiplies frames by a *per-frequency-bin* window
+tensor `analysis_window: [freq_bins, frames, n_fft]` (broadcasting over
+`freq_bins`/`frames` where those dims are `1`), producing a
+`[batch, freq_bins, frames, n_fft]` tensor of tapered frames, then (2)
+contracts against a DFT twiddle matrix with `torch.einsum("bftk,fk->bft", ...)`
+— literally computing, for each `(batch, freq, frame)`, the DFT sum over the
+local sample index `k` by hand instead of via `torch.fft`. Slower (an
+explicit matrix contraction rather than an FFT), but it's the only way to let
+frequency bin `m`'s DFT use a window that no other bin shares. The same
+phase-correction step as the FFT backend is applied afterward.
+
+Read together, `fdstft_fft_forward` and `adstft_dft_forward` implement the
+*same* transform when their window happens to be frequency-independent —
+`_core.py`'s comments call out that `adstft_dft_forward` follows the
+`torch.stft` convention over the *local* frame index and therefore does
+**not** need the extra phase factor baked into the twiddle matrix itself
+(the phase correction is applied as a separate multiplication after the
+`einsum`, mirroring the FFT path).
+
+## Inverse: adjoint, WOLA, and CG
+
+### `overlap_add_wola(*, frames, frame_positions, analysis_window, signal_length, eps) -> Tensor[batch, signal_length]`
+
+A weighted overlap-add reconstruction that loops over frames in Python
+(`for t in range(num_frames)`), scatter-adding each windowed frame into the
+output signal and separately accumulating the sum of squared window values
+per output sample, then dividing (`num / (den + eps)`). This is the
+straightforward, unvectorized reference implementation; `overlap_add_dual`
+below is the vectorized version actually used by `DSTFT.inverse`.
+
+### `overlap_add_dual(*, frames, frame_positions, analysis_window, signal_length, eps) -> Tensor[batch, signal_length]`
+
+The version `DSTFT.inverse()` actually calls for its FFT-backend path. Same
+weighted-overlap-add idea as `overlap_add_wola`, but vectorized using
+`index_add_` instead of a Python loop over frames — flattens the
+`(frame, local-sample)` grid into 1D index/value arrays once, then does two
+`index_add_` scatter-sums (one to build the denominator, one to build the
+weighted numerator) instead of iterating. Functionally equivalent, much
+faster on GPU. This is why `DSTFT.inverse()` achieves exact reconstruction
+on the FFT backend: the numerator of this division is, by construction,
+`x[p] * (sum of squared window values at p)`, which exactly cancels the
+denominator wherever a sample is actually covered by at least one frame.
+
+### `overlap_add_dual_dft_wola_den(*, analysis_window, n_fft, frame_positions, signal_length, eps) -> Tensor[signal_length]`
+
+Computes just the denominator (not the full reconstruction) for the
+DFT-backend inverse, accounting for the fact that a real-valued signal's
+`rfft` only stores non-negative frequencies — each bin except DC (and
+Nyquist, if present) actually represents *two* symmetric frequency
+components, so it must be weighted by `2` (`c_m`) rather than `1` when
+summing squared-window energy across frequency bins. This denominator is
+reused both as the normalizer for the fast `"wola"` inverse method and as a
+diagonal *preconditioner* for the `"cg"` method's conjugate-gradient solve.
+
+### `adstft_dft_forward`'s adjoint — `adstft_dft_adjoint(*, stft, analysis_window, n_fft, frame_positions, signal_length) -> Tensor[batch, signal_length]`
+
+The exact linear adjoint `A*` of `adstft_dft_forward`, i.e. the operation you
+compose with a denominator (either the WOLA diagonal above, for a fast
+approximate inverse, or as one step of a conjugate-gradient loop against
+`(A*A + λI)`, for an accurate one). Undoes the forward phase-correction
+factor (conjugated), applies the same rFFT multiplicity weights `c_m`, then
+runs an einsum against the conjugate-transposed twiddle matrix and
+scatter-adds the result back onto the time axis with a Python loop (this
+function is explicitly the exact/reference adjoint, not the CUDA-fast path —
+it trades vectorization for correctness/clarity where the two matter more,
+since it's also used as the residual computation inside `cg_solve`).
+
+### `cg_solve(*, apply_mat, b, x0=None, max_iter=200, tol=1e-10, precond=None) -> Tensor`
+
+A generic, batched preconditioned conjugate-gradient solver for symmetric
+positive-definite linear systems `apply_mat(x) = b`. Doesn't know anything
+about DSTFT specifically — `apply_mat` is passed in as a closure by
+`DSTFT.inverse()`'s `"cg"` branch, composed from `adstft_dft_forward` +
+`adstft_dft_adjoint` + a `λI` regularization term (`apply_a` → `apply_at` →
+`+ cg_lambda * x`), and `precond` is a diagonal preconditioner built from
+`overlap_add_dual_dft_wola_den`. Standard PCG: iterates residual/search
+direction updates until either the relative residual drops below `tol` or
+`max_iter` is reached, guarding the step-size denominator against
+near-zero values to avoid division blow-ups on nearly-singular systems.

--- a/markdown_docs/src/dstft/dstft.md
+++ b/markdown_docs/src/dstft/dstft.md
@@ -1,0 +1,200 @@
+# `dstft/dstft.py`
+
+The single user-facing module. Contains the `DSTFT` class and the small
+supporting type aliases/protocol that describe its configuration surface.
+Per the module docstring, this file is deliberately an "API/state holder" —
+it validates inputs, manages learnable parameters, and picks which backend
+to call, but the actual transform math lives in `_core.py`.
+
+## Type aliases and `WindowFn`
+
+- `Normalization = None | Literal["unit", "paper", "contract"]` — passed
+  through to the window function; see `windows.md`.
+- `WindowMode = Literal["fixed", "constant", "time", "frequency", "time-frequency"]`
+  — controls both which of `theta`'s two axes (frequency, time) are allowed
+  to vary, and, as a side effect, which backend gets selected (see below).
+- `HopMode = Literal["fixed", "constant", "time"]` — the hop-length analog of
+  `WindowMode`, but with only a time axis (there's no "hop length that varies
+  by frequency bin" — hop length determines frame *positions*, which are
+  shared across all frequency bins of a frame).
+- `WindowFn` (a `Protocol`) — the exact call signature any window function
+  must implement to be pluggable into `DSTFT(window=...)`. `hann_window` in
+  `windows.py` is the only implementation today, but this protocol is what
+  would let a caller supply their own window shape without modifying this
+  file.
+
+## `class DSTFT(nn.Module)`
+
+### `__init__(self, *, n_fft, win_length=None, hop_length=None, window_mode="time", hop_mode="fixed", window="hann", normalization=None, hop_length_min=1.0, hop_length_max=None, win_length_min=None, win_length_max=None, magnitude_power=1.0, eps=1e-12)`
+
+Validates all the numeric arguments (positivity checks on `n_fft`,
+`hop_length`, `win_length`, `magnitude_power`, `eps`), then sets up two kinds
+of state:
+
+1. **Configuration** — plain Python attributes (`n_fft`, `freq_bins =
+   n_fft // 2 + 1`, `window_mode`, `hop_mode`, the min/max bounds, etc.), all
+   fixed for the module's lifetime.
+2. **Learnable parameters, stored in an unconstrained form.** `win_length`
+   and `hop_length` are not stored directly as `nn.Parameter`s in their
+   user-facing units. Instead, `_raw_win_length` / `_raw_hop_length` hold an
+   unconstrained real number that gets mapped through a `sigmoid`, then
+   affinely rescaled into `[min, max]` — see `_effective_win_length` /
+   `_effective_hop_length` below. This is a standard reparameterization trick
+   for **bounded** learnable parameters: an unconstrained value can be
+   optimized with plain gradient descent without ever needing a projection
+   step to keep it in-bounds, because the sigmoid does that automatically.
+   The constructor solves for the initial raw value that makes
+   `sigmoid(raw)` produce the user's requested initial `win_length`/
+   `hop_length` exactly (the `torch.log(p) - torch.log1p(-p)` lines are the
+   logit function, i.e. `sigmoid`'s inverse).
+
+   Whether these parameters actually require gradients is decided by
+   `window_mode`/`hop_mode`: `"fixed"` never requires grad; anything else
+   does. Note this means `"constant"` *is* learnable (a single scalar that
+   the whole module shares) — the difference from `"fixed"` is trainability,
+   not shape.
+
+   Frame-shaped parameters (one value per frame, or per frequency bin, or
+   both) are **not** allocated here — their size depends on the input
+   signal's length, which isn't known until `initialize(x)` is called. The
+   constructor only allocates a placeholder scalar; `initialize()` expands it
+   to the right shape.
+
+3. **Backend dispatch, resolved once.** `self._transform_fn` is bound to
+   either `_core.adstft_dft_forward` (if `window_mode` is `"frequency"` or
+   `"time-frequency"`) or `_core.fdstft_fft_forward` (otherwise) — decided
+   once in `__init__`, not re-checked on every `forward()` call, so there's
+   no per-call branching cost. Same idea for `self._window_fn`, resolved via
+   `_resolve_window`.
+
+### `forward(self, x) -> (spec, stft)`
+
+The main transform. Requires `initialize(x)` to have been called first (this
+is enforced with a `RuntimeError`, not silently auto-initializing — the
+docstring is explicit that this is deliberate, since auto-initializing on
+first `forward()` could silently lock in a signal length the caller didn't
+intend to commit to). Steps:
+
+1. Compute frame center positions via `self.frame_centers(...)`.
+2. Extract raw frames and the floor/frac split via `_core.unfold_floor_frac`.
+3. Evaluate the analysis window at the module's current *effective* window
+   length (`self._effective_win_length(...)`, the sigmoid-mapped `theta`) via
+   `self._window_fn`.
+4. A shape sanity-check on the returned window, branching on `window_mode`
+   (2D/3D for the FFT-eligible modes, always 3D for the DFT modes) — this is
+   defensive validation against a custom `window=` callable returning the
+   wrong rank, not something that fires with the built-in `hann_window`.
+5. Dispatch to `self._transform_fn` (one of the two `_core` backends).
+6. Compute the magnitude spectrogram: `spec = stft.abs().pow(magnitude_power)
+   + eps` — note the `eps` is added *after* the power, as a floor, primarily
+   so a downstream `.log()` (as used in `visualization.plot_spec`) never sees
+   an exact zero.
+
+Returns both `spec` (real, `[batch, freq, frames]`) and `stft` (complex,
+same shape) — the complex `stft` is what you need to pass to `inverse()`
+later; `spec` alone has thrown away the phase.
+
+### `inverse(self, stft, *, method="auto", cg_max_iter=20, cg_tol=1e-8, cg_lambda=1e-6) -> Tensor[batch, time]`
+
+Reconstructs a time-domain signal from a complex `stft` tensor. The
+docstring on this method is unusually detailed for the codebase and is worth
+reading directly for the exact reconstruction identity — see also
+`_core.md` for how `overlap_add_dual` achieves exact recovery. In brief:
+
+- `method="auto"` resolves to `"wola"` on the FFT backend (exact) or `"cg"`
+  on the DFT backend (approximate but more accurate than `"wola"` there).
+- `method="wola"` on the FFT backend: undoes the forward pass's Eq. (25)
+  phase factor, runs `torch.fft.irfft` to get back per-frame time-domain
+  frames, then calls `_core.overlap_add_dual` to recombine them — this is the
+  path that reconstructs the original signal exactly (on the region actually
+  covered by at least one frame).
+- On the DFT backend (`window_mode` in `{"frequency", "time-frequency"}`),
+  neither `"wola"` nor `"cg"` are exact — the operator isn't easily
+  invertible when every frequency bin has its own window. `"wola"` applies
+  the adjoint (`_core.adstft_dft_adjoint`) and normalizes by an approximate
+  diagonal (fast, one adjoint call). `"cg"` instead solves
+  `(A*A + λI) x = A*s` iteratively with `_core.cg_solve`, using the same
+  diagonal as a preconditioner — more accurate, more expensive
+  (`cg_max_iter` iterations of forward+adjoint each).
+
+Note there is also an `_inverse_dft_exact` method further down the file that
+currently just raises `NotImplementedError` unconditionally (with dead code
+below the `raise` that was presumably a work-in-progress exact DFT-backend
+inverse via CG against the full Gram operator, left in place but disabled —
+worth knowing about if `"cg"`'s accuracy on the DFT backend is ever
+insufficient and someone wants to pick this back up).
+
+### `frame_centers(self, *, device=None, dtype=None) -> Tensor[frames]`
+
+Returns the current frame center positions `t_n`. Must be called after
+`initialize()`. If `hop_mode == "time"`, positions come from a **cumulative
+sum** of the (learnable, per-frame) effective hop lengths — i.e. each frame's
+position is literally "wherever the previous frame ended up, plus this
+frame's own hop" — which is what makes hop *lengths* learnable translate into
+learnable frame *positions* without ever storing positions directly as
+parameters. Otherwise (fixed/constant hop), positions come from
+`_core.compute_frame_positions_fixed_hop` using the single effective hop
+value.
+
+### `hop_length` / `win_length` (properties)
+
+Public read accessors for the *effective* (constrained, sigmoid-mapped)
+values — never the raw unconstrained parameters. This is the only way
+user code is meant to read the current window/hop length; `_raw_win_length`
+and `_raw_hop_length` are private.
+
+### `_effective_win_length` / `_effective_hop_length`
+
+The sigmoid reparameterization itself:
+`min + (max - min) * sigmoid(raw)`. Small, private, and called from several
+places (`forward`, `inverse`, the public properties above) — this is the
+single source of truth for "what does the raw parameter currently mean in
+real units."
+
+### `plot_spec` / `plot_win_lengths`
+
+Thin instance-method wrappers around `visualization.plot_spec` /
+`visualization.plot_win_lengths` (imported lazily, inside the method, to
+avoid importing matplotlib at module import time for users who never plot).
+`plot_win_lengths` additionally fills in `vmin`/`vmax` from the module's own
+`win_length_min`/`win_length_max` if the caller didn't specify them, and
+requires the module to already be initialized (it needs `_init_device`/
+`_init_dtype` to read `self.win_length`).
+
+### `_resolve_window(self, window) -> WindowFn`
+
+Converts the constructor's `window=` argument (a string identifier or a
+callable) into an actual callable. Today the only supported string is
+`"hann"`, mapped to `windows.hann_window`; any other string raises
+`ValueError`, and anything callable is accepted as-is (assumed to satisfy
+the `WindowFn` protocol — not checked at runtime beyond `callable(window)`).
+
+### `initialize(self, x)`
+
+Must be called once, before the first `forward()`/`inverse()`, with an
+example input `x: [batch, time]`. This is where every input-length-dependent
+piece of state actually gets allocated:
+
+- Validates `x` is 2D and at least `n_fft` samples long.
+- If already initialized, this call becomes idempotent **only if** the new
+  `x` has the same signal length, device, and dtype as before — any mismatch
+  raises `RuntimeError` rather than silently re-initializing (the module is
+  explicitly meant to be reused across forward passes on same-shaped inputs
+  from the same batch/dataset, not to silently support changing input shapes
+  mid-training).
+- Computes `self._num_frames` from a **detached** hop-length value (see the
+  comment in the source: frame *count* must not depend on a
+  gradient-tracked tensor, since shapes participate in the computation
+  graph's structure, not its values).
+- Expands `_raw_win_length` and `_raw_hop_length` from their placeholder
+  shape into the actual shape implied by `window_mode`/`hop_mode` (scalar,
+  `[1, num_frames]`, `[freq_bins, 1]`, or `[freq_bins, num_frames]` for the
+  window; scalar or `[num_frames]` for the hop), always re-wrapped as a new
+  `nn.Parameter` with the correct `requires_grad`.
+- Finishes with `self._validate_parameter_shapes()` (a private consistency
+  check — every learnable tensor's shape must be broadcastable against
+  `freq_bins`/`num_frames`) and sets `self._initialized = True`.
+
+The whole method is decorated `@torch.no_grad()` — this setup step (shape
+allocation, parameter re-wrapping) is not itself something to backpropagate
+through.

--- a/markdown_docs/src/dstft/visualization.md
+++ b/markdown_docs/src/dstft/visualization.md
@@ -1,0 +1,52 @@
+# `dstft/visualization.py`
+
+Two matplotlib-based plotting helpers. Both are plain functions (no
+dependency on `DSTFT` itself — they take tensors, not a module instance),
+and both are also re-exported as convenience methods on `DSTFT`
+(`DSTFT.plot_spec`, `DSTFT.plot_win_lengths` in `dstft.py`), which just
+forward to these with a couple of `DSTFT`-derived defaults filled in
+(`vmin`/`vmax` from `win_length_min`/`win_length_max`).
+
+## `plot_spec(spec, *, colorbar=True, title=None, xlabel="frames", ylabel="frequency bins", cmap="inferno", figsize=(10.0, 4.0), ax=None, show=True, **imshow_kwargs) -> (fig, ax)`
+
+Plots a magnitude spectrogram as a heatmap. Expects `spec` with shape
+`[batch, freq, frames]` and only plots the **first item of the batch**
+(`spec[0]`) — this is a single-spectrogram debugging/inspection plot, not a
+batch-aware grid.
+
+Before plotting, the data is detached, moved to CPU, cast to `float32`, and
+put on a **log scale** (`(data + eps).log()`, using the dtype's own epsilon
+to avoid `log(0)`). This log-magnitude view is standard for spectrograms —
+raw linear magnitude is dominated by a few loud bins and hides everything
+else.
+
+Accepts an existing `ax` to plot into (for building multi-panel figures —
+see how `notebooks/window_modes.ipynb` uses this to lay out several modes
+side by side in one figure) or creates a new one via `plt.subplots(figsize)`
+if none is given. Any extra keyword arguments are forwarded straight to
+`ax.imshow(...)`, so callers can override `vmin`/`vmax`/`interpolation`/etc.
+without this function needing to know about them explicitly.
+
+## `plot_win_lengths(win_length, *, vmin=None, vmax=None, colorbar=True, title=None, xlabel="frames", ylabel="frequency bins", cmap="inferno", figsize=(10.0, 4.0), ax=None, show=True) -> (fig, ax)`
+
+Plots a window-length (or hop-length — the function is generic over
+whichever tensor you pass it) parameter as a 2D heatmap, regardless of its
+actual rank. `win_length` can be:
+
+- a plain Python `float`/`int` (a scalar `theta`, e.g. `window_mode="fixed"`
+  or `"constant"`) — reshaped to a `[1, 1]` image,
+- a 1D tensor `[frames]` (`window_mode="time"`, or a hop-length tensor) —
+  reshaped to `[1, frames]`,
+- a 2D tensor `[freq_bins, frames]` (`window_mode="frequency"` or
+  `"time-frequency"`) — plotted as-is.
+
+Any other rank raises `ValueError`. This "always show it as a 2D image, even
+a 1x1 or 1xN one" approach is what lets one function visualize the parameter
+regardless of which `window_mode` produced it, without the caller having to
+branch.
+
+Note that unlike `plot_spec`, this function does **not** apply a log
+transform — window/hop lengths are plotted on a linear scale, which is why
+`vmin`/`vmax` are exposed as explicit parameters (so callers can pin the
+color scale to the module's configured `win_length_min`/`win_length_max`
+bounds, which is exactly what `DSTFT.plot_win_lengths` does by default).

--- a/markdown_docs/src/dstft/windows.md
+++ b/markdown_docs/src/dstft/windows.md
@@ -1,0 +1,63 @@
+# `dstft/windows.py`
+
+Window functions for DSTFT. Currently a single function, `hann_window`, but
+the module docstring states the intent explicitly: this file is meant to host
+more window families later, with `hann_window`'s signature acting as the
+template every future window function should match (a fixed keyword-only
+signature is what lets `DSTFT` treat "which window" as a pluggable strategy —
+see `WindowFn` / `WindowSpec` in `dstft.py`).
+
+## `hann_window(*, n_fft, theta, idx_frac, freq_bins, frames, device, dtype, normalization) -> torch.Tensor`
+
+Evaluates a Hann-family window whose **effective length is `theta`**, not
+`n_fft`. This is the crux of the whole package: `theta` is an arbitrary
+tensor (constant, or one value per time frame, or one per frequency bin, or
+one per time-frequency cell) and can carry gradients, so an optimizer can
+shrink or grow the window shape by adjusting `theta` directly.
+
+**Shape contract.** `theta` must always be a 2D tensor
+`[freq_bins_dim, frames_dim]` where each dimension is either `1`
+(broadcast) or the true size — this uniform 2D-with-broadcast convention is
+what lets the same function handle all four `window_mode` cases without
+branching on the caller's side:
+
+| `theta` shape | Resulting window shape | Corresponds to `window_mode` |
+|---|---|---|
+| `[1, 1]` (scalar) | `[1, 1, n_fft]` | `"fixed"` / `"constant"` |
+| `[1, frames]` | `[1, frames, n_fft]` | `"time"` |
+| `[freq_bins, 1]` | `[freq_bins, 1, n_fft]` | `"frequency"` |
+| `[freq_bins, frames]` | `[freq_bins, frames, n_fft]` | `"time-frequency"` |
+
+**How the window is actually evaluated.** The function builds a centered
+integer support `k_rel = arange(n_fft) - n_fft/2`, subtracts the fractional
+frame offset `idx_frac` (this is what lets a frame center land between
+samples rather than only on integer sample indices — see `_core.py`'s
+floor/frac split), and then evaluates a raised-cosine (Hann) shape on that
+support. Two different formulas are used depending on `normalization`:
+
+- `normalization in {"paper", "contract"}`: uses the exact contraction from
+  the underlying paper, `ω(x, θ) = (L/θ) · ω_L((L/θ) · x)` where `L = n_fft`
+  — i.e. the window is literally the fixed-length Hann window rescaled in
+  both its argument and its amplitude by `n_fft / theta`. This is the
+  mathematically "correct" contracted window and is also what keeps energy
+  roughly constant as `theta` shrinks (the `* scale` amplitude term).
+- Anything else (including `None`): a more direct formula, a Hann shape
+  evaluated on a window of width `theta` directly, zero outside `[0, theta)`.
+  Simpler, but does not preserve the same energy-normalization property as
+  the paper's contraction.
+
+After that, `normalization` is applied a second time, independently of the
+shape formula above:
+
+- `None` or `"paper"`/`"contract"` (already handled above): returned as-is.
+- `"unit"`: the window is divided by its own sum along the last axis (with an
+  epsilon floor to avoid division by zero), so each window sums to 1 —
+  useful when you want the window's total energy/weight to be independent of
+  `theta`.
+- Anything else: raises `ValueError`.
+
+**Why `idx_frac` and not just `theta`.** Note that `idx_frac` shifts *where*
+the window is centered within its fixed `n_fft`-sample support, while `theta`
+controls *how wide* the window is. These are independent degrees of freedom:
+a frame can have a fractional center position (continuous frame placement)
+independently of whatever its window length currently is.

--- a/markdown_docs/summary.md
+++ b/markdown_docs/summary.md
@@ -1,0 +1,79 @@
+# dstft — project summary
+
+Generated documentation of the codebase, module by module. This mirrors what
+a RepoAgent run would produce (see `TOOLING.md` / `TODO.md` `[+repoagent-key]`
+for why this was written directly instead of via RepoAgent+Gemini for this
+pass), written by reading the actual source rather than only the docstrings.
+
+## What this package does
+
+`dstft` implements a **Differentiable Short-Time Fourier Transform**: a
+PyTorch `nn.Module` (`DSTFT`, in `dstft.py`) that computes a spectrogram the
+same way `torch.stft` would, except every parameter that normally has to be
+fixed up front — the analysis window's length, and the spacing between
+frames — can instead be a learnable tensor. Because the whole transform is
+implemented with differentiable PyTorch ops, gradients flow from a downstream
+loss (e.g. "make this spectrogram sparse") back into the window length or hop
+length, letting an optimizer discover a time-frequency tiling adapted to the
+signal instead of a hand-picked one.
+
+## Module map
+
+| Module | Role |
+|---|---|
+| `dstft/__init__.py` | Public API surface: exports `DSTFT`, `plot_spec`, `plot_win_lengths`, `__version__`. |
+| `dstft/dstft.py` | The `DSTFT` class itself — the only class users are expected to import directly. Holds configuration/state, validates inputs, and dispatches the actual math to `_core.py`. |
+| `dstft/_core.py` | Pure-function math kernels: frame extraction, the two forward-transform backends (FFT-based and DFT-based), their adjoints, overlap-add reconstruction, and a small conjugate-gradient solver. No class state — everything is explicit tensors in, tensors out. |
+| `dstft/windows.py` | Window functions. Currently one: a parameterized Hann window that can be evaluated at a continuous, learnable length `theta` and shifted by a fractional sample offset. |
+| `dstft/visualization.py` | Two plotting helpers (`plot_spec`, `plot_win_lengths`) built on matplotlib, also exposed as convenience methods on `DSTFT`. |
+
+## The two backends, and why there are two
+
+`DSTFT.__init__` picks one of two transform implementations based on
+`window_mode`, and this choice is **not** user-configurable directly — it's
+implied by whether the window is allowed to vary across frequency:
+
+- **FFT backend** (`_core.fdstft_fft_forward`) — used when `window_mode` is
+  `"fixed"`, `"constant"`, or `"time"` (i.e. the window may change from frame
+  to frame, but is the same for every frequency bin within a frame). This lets
+  the implementation use one shared window per frame and a real FFT
+  (`torch.fft.rfft`), which is fast.
+- **DFT backend** (`_core.adstft_dft_forward`) — used when `window_mode` is
+  `"frequency"` or `"time-frequency"`, i.e. the window itself depends on which
+  frequency bin is being computed. An FFT can no longer be reused across bins
+  in that case, so this backend falls back to an explicit matrix
+  multiplication against a DFT twiddle-factor matrix (`torch.einsum`), which
+  is more expensive but supports arbitrary per-bin windows.
+
+Both backends implement the same non-integer-frame-position convention from
+the underlying paper: a frame center `t_n` is split into an integer part
+(`floor(t_n)`, used for indexing) and a fractional part (`frac(t_n)`, used to
+continuously shift the window and to apply a phase-correction factor in the
+frequency domain — see the "Eq. (25)" comments in `_core.py`). This is what
+lets frame *positions* (via `hop_mode="time"`) be learnable too, not just
+window length.
+
+## Inversion
+
+`DSTFT.inverse()` reconstructs a time-domain signal from a `stft` tensor.
+Which method actually runs depends on the backend:
+
+- On the FFT backend, inversion is **exact** on the covered region: the
+  forward pass's per-frame windowing and phase convention are undone, then a
+  weighted overlap-add (`_core.overlap_add_dual`) recombines frames using the
+  analysis window as its own synthesis window, normalized by the local sum of
+  squared window values. Because the numerator of that normalization equals
+  `x[p] * (denominator)` for every covered sample `p`, the division exactly
+  cancels and returns the original signal.
+- On the DFT backend, exact inversion isn't available (the "frequency" and
+  "time-frequency" window modes make the forward operator ill-conditioned to
+  invert directly), so `inverse()` offers two approximations: `"wola"` (fast,
+  applies the adjoint operator `_core.adstft_dft_adjoint` and normalizes by an
+  approximate diagonal, i.e. a diagonal preconditioner) and `"cg"` (slower but
+  more accurate — solves `(A*A + λI)x = A*s` with a preconditioned conjugate
+  gradient solver, `_core.cg_solve`, using the same diagonal as a
+  preconditioner).
+
+See `notebooks/inverse.ipynb` for a worked example comparing these, and
+`notebooks/window_modes.ipynb` for a tour of every `window_mode`/`hop_mode`
+combination.


### PR DESCRIPTION
## Summary
- RepoAgent hit a real quota wall tonight (Gemini free tier, 5 req/min vs 4 concurrent workers — see `TODO.md` `[+repoagent-key]`), and separately its `--base-url` targets an OpenAI-wire-compatible endpoint, which Anthropic's API is not (no OpenAI-compatible shim at `api.anthropic.com`; RepoAgent's HTTP client is `llama_index`'s OpenAI client) — so a Claude API key isn't a drop-in swap without a translation proxy.
- Generated the equivalent output directly: `markdown_docs/` with one file per `src/dstft/` module, mirroring RepoAgent's default output layout, written by reading the actual source (not just paraphrasing docstrings) — covers the floor/frac frame-position convention, why there are two transform backends and which `window_mode` picks which, how each `inverse()` method reconstructs (exactly or approximately), and the sigmoid reparameterization behind bounded learnable `win_length`/`hop_length`.
- This is a contributor-facing internals doc, distinct from `docs/` (Sphinx, the polished versioned reference manual for package users built from docstrings) — it doesn't touch or duplicate that.

## Test plan
- [x] `pytest` — 64 passed (no code changes, docs-only)
- [x] `pre-commit run` on the new files — all hooks pass
- [x] `SPHINX_OFFLINE=1 sphinx-build -b html docs <out> -W --keep-going` — unaffected, builds clean
- [ ] Human read-through for accuracy (I verified against the source while writing it, but a second pair of eyes on the math/DSP claims is worthwhile)

---
_Generated by [Claude Code](https://claude.ai/code/session_01KyjjDHc4vpTx6jDv1rWfC7)_