### PR TITLE
Wire markdown_docs/ into the published Sphinx docs

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -38,3 +38,4 @@ DSTFT
    citation
    api
    notebooks
+   internals

--- a/docs/internals.rst
+++ b/docs/internals.rst
@@ -1,0 +1,18 @@
+Internals
+=========
+
+Generated, module-by-module documentation of the codebase (written from a
+direct reading of ``src/dstft/*.py``, in the style RepoAgent would produce —
+see ``TOOLING.md`` at the repository root for why it was written directly
+instead of via RepoAgent+Gemini for this pass). Useful if you want to
+understand how the transform is implemented, not just how to call it.
+
+.. toctree::
+   :maxdepth: 1
+
+   markdown_docs/summary
+   markdown_docs/src/dstft/__init__
+   markdown_docs/src/dstft/dstft
+   markdown_docs/src/dstft/_core
+   markdown_docs/src/dstft/windows
+   markdown_docs/src/dstft/visualization

--- a/docs/markdown_docs
+++ b/docs/markdown_docs
@@ -1,0 +1,1 @@
+../markdown_docs


### PR DESCRIPTION
## Summary
- Adds `docs/markdown_docs` as a symlink to `../markdown_docs`, so the RepoAgent-style module documentation merged in #19 is part of the ReadTheDocs build instead of only living as repo-root markdown.
- Adds `docs/internals.rst` (new "Internals" toctree page) and wires it into `docs/index.rst`.

## Test plan
- [x] `sphinx-build -b html docs <out> -W --keep-going` locally — build succeeds, symlink is followed, no orphan-document warnings.
- [x] `pre-commit run` on changed files — passes.
- [ ] CI (lint/test/docs) green on this PR.

---
_Generated by [Claude Code](https://claude.ai/code/session_01KyjjDHc4vpTx6jDv1rWfC7)_