### PR TITLE
Add CITATION.cff and a landing-page pitch paragraph

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,41 @@
+cff-version: 1.2.0
+message: >-
+  If you use this software, please cite it using the metadata below, and
+  consider citing the associated paper (see "preferred-citation"). See
+  https://dstft.readthedocs.io/en/latest/citation.html for the full list of
+  related publications.
+title: dstft
+abstract: >-
+  Differentiable Short-Time Fourier Transform (DSTFT) for PyTorch: a
+  gradient-based, learnable time-frequency representation whose window
+  length and hop length can be optimized like any other neural network
+  parameter, instead of being fixed up front.
+authors:
+  - given-names: Maxime
+    family-names: Leiber
+license: MIT
+repository-code: https://github.com/maxime-leiber/dstft
+url: https://dstft.readthedocs.io
+type: software
+preferred-citation:
+  type: article
+  title: >-
+    Optimal Adaptive Time-Frequency Representation via Differentiable
+    Short-Time Fourier Transform
+  authors:
+    - given-names: Maxime
+      family-names: Leiber
+    - given-names: Yosra
+      family-names: Marnissi
+    - given-names: Axel
+      family-names: Barrau
+    - given-names: Sylvain
+      family-names: Meignen
+    - given-names: Laurent
+      family-names: Massoulié
+  journal: IEEE Transactions on Signal Processing
+  year: 2025
+  volume: 73
+  start: 5047
+  end: 5059
+  doi: 10.1109/TSP.2025.3624477

--- a/README.md
+++ b/README.md
@@ -8,7 +8,9 @@
 [![License](https://img.shields.io/github/license/maxime-leiber/dstft.svg)](LICENSE)
 [![IEEE TSP](https://img.shields.io/badge/IEEE_TSP-DSTFT-00629B?logo=ieee&logoColor=white)](https://ieeexplore.ieee.org/abstract/document/11220928)
 
-**DSTFT** (Differentiable Short-Time Fourier Transform) is a PyTorch module for a differentiable short-time Fourier transform, supporting learnable/adaptive parameters.
+**dstft** implements a **Differentiable Short-Time Fourier Transform**: a PyTorch `nn.Module` (`DSTFT`) that computes a spectrogram conceptually like `torch.stft`, except every parameter that normally has to be fixed up front — the analysis window's length, and the spacing between frames — can instead be a learnable tensor. Because the whole transform is implemented with differentiable PyTorch ops, gradients flow from a downstream loss (e.g. "make this spectrogram sparse") back into the window length or hop length, letting an optimizer discover a time-frequency tiling adapted to the signal instead of a hand-picked one.
+
+Unlike `torch.stft`, `DSTFT` is initialized once per signal length (`dstft.initialize(x)`) and returns both the magnitude spectrogram and the complex transform (`spec, stft = dstft(x)`) — see the usage example below.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 
 **dstft** implements a **Differentiable Short-Time Fourier Transform**: a PyTorch `nn.Module` (`DSTFT`) that computes a spectrogram conceptually like `torch.stft`, except every parameter that normally has to be fixed up front — the analysis window's length, and the spacing between frames — can instead be a learnable tensor. Because the whole transform is implemented with differentiable PyTorch ops, gradients flow from a downstream loss (e.g. "make this spectrogram sparse") back into the window length or hop length, letting an optimizer discover a time-frequency tiling adapted to the signal instead of a hand-picked one.
 
-Unlike `torch.stft`, `DSTFT` is initialized once per signal length (`dstft.initialize(x)`) and returns both the magnitude spectrogram and the complex transform (`spec, stft = dstft(x)`) — see the usage example below.
+Unlike `torch.stft`, `DSTFT` is initialized once per signal length (`dstft.initialize(x)`) and returns both the magnitude spectrogram and the complex transform (`spec, stft = dstft(x)`) — see the usage example below. Each instance is tied to the signal length it was first initialized with; reinitializing with a different length raises `RuntimeError` (create a new instance instead).
 
 ---
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -25,6 +25,16 @@ DSTFT
    :target: https://github.com/maxime-leiber/dstft/blob/main/LICENSE
    :alt: License
 
+**dstft** implements a **Differentiable Short-Time Fourier Transform**: a
+PyTorch ``nn.Module`` (``DSTFT``) that computes a spectrogram the
+same way ``torch.stft`` would, except every parameter that normally has to be
+fixed up front — the analysis window's length, and the spacing between
+frames — can instead be a learnable tensor. Because the whole transform is
+implemented with differentiable PyTorch ops, gradients flow from a downstream
+loss (e.g. "make this spectrogram sparse") back into the window length or hop
+length, letting an optimizer discover a time-frequency tiling adapted to the
+signal instead of a hand-picked one.
+
 .. image:: _static/opt.gif
    :alt: Optimization demo
    :width: 600

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -26,14 +26,19 @@ DSTFT
    :alt: License
 
 **dstft** implements a **Differentiable Short-Time Fourier Transform**: a
-PyTorch ``nn.Module`` (``DSTFT``) that computes a spectrogram the
-same way ``torch.stft`` would, except every parameter that normally has to be
-fixed up front — the analysis window's length, and the spacing between
-frames — can instead be a learnable tensor. Because the whole transform is
-implemented with differentiable PyTorch ops, gradients flow from a downstream
-loss (e.g. "make this spectrogram sparse") back into the window length or hop
-length, letting an optimizer discover a time-frequency tiling adapted to the
-signal instead of a hand-picked one.
+PyTorch ``nn.Module`` (``DSTFT``) that computes a spectrogram conceptually
+like ``torch.stft``, except every parameter that normally has to be fixed up
+front — the analysis window's length, and the spacing between frames — can
+instead be a learnable tensor. Because the whole transform is implemented
+with differentiable PyTorch ops, gradients flow from a downstream loss (e.g.
+"make this spectrogram sparse") back into the window length or hop length,
+letting an optimizer discover a time-frequency tiling adapted to the signal
+instead of a hand-picked one.
+
+Unlike ``torch.stft``, ``DSTFT`` is initialized once per signal length
+(``dstft.initialize(x)``) and returns both the magnitude spectrogram and the
+complex transform (``spec, stft = dstft(x)``) — see :doc:`getting_started`
+for a full example.
 
 .. image:: _static/opt.gif
    :alt: Optimization demo

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -38,7 +38,9 @@ instead of a hand-picked one.
 Unlike ``torch.stft``, ``DSTFT`` is initialized once per signal length
 (``dstft.initialize(x)``) and returns both the magnitude spectrogram and the
 complex transform (``spec, stft = dstft(x)``) — see :doc:`getting_started`
-for a full example.
+for a full example. Each instance is tied to the signal length it was first
+initialized with; reinitializing with a different length raises
+``RuntimeError`` (create a new instance instead).
 
 .. image:: _static/opt.gif
    :alt: Optimization demo


### PR DESCRIPTION
## Summary
- `CITATION.cff` (repo root): machine-readable citation metadata, enables GitHub's "Cite this repository" button. `preferred-citation` points at the primary IEEE TSP paper; the fuller list of related publications stays in `docs/citation.rst`. Validated with `cffconvert --validate` (schema 1.2.0). `version`/`date-released` intentionally omitted since `v3.0.0` hasn't been tagged yet — worth filling in once it is.
- `docs/index.rst`: the homepage went straight from badges to a demo gif with no explanation of what the package does. Added a pitch paragraph between the badges and the gif (badges → pitch → gif → table of contents).

## Test plan
- [x] `cffconvert --validate -i CITATION.cff` — valid
- [x] `pre-commit run` — passes
- [x] `SPHINX_OFFLINE=1 sphinx-build -b html docs  -W --keep-going` — builds clean
- [x] `pytest` — 75 passed

---
_Generated by [Claude Code](https://claude.ai/code/session_01KyjjDHc4vpTx6jDv1rWfC7)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Expanded documentation and README content describing the differentiable short-time Fourier transform, learnable time-frequency parameters, gradient optimization, initialization behavior, and spectrogram outputs.
  * Documented reinitialization behavior when signal lengths differ.
  * Added software citation metadata, including project information, licensing, repository, documentation, and the preferred academic reference.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->