### PR TITLE
Quick wins: .gitattributes, Colab badge, README example, gradcheck/torch.stft-parity/CUDA tests, CI 3.12

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+notebooks/*.ipynb linguist-generated=true
+docs/notebooks/*.ipynb linguist-generated=true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.10", "3.11"]
+        python-version: ["3.10", "3.11", "3.12"]
 
     steps:
       - uses: actions/checkout@v7

--- a/README.md
+++ b/README.md
@@ -94,6 +94,25 @@ dstft.initialize(x)
 spec, stft = dstft(x)
 ```
 
+Since `window_mode="constant"` makes `win_length` a learnable parameter, it
+can be optimized directly by gradient descent — no separate API, just a
+normal PyTorch training loop against any loss defined on `spec`/`stft`:
+
+```python
+optimizer = torch.optim.Adam(dstft.parameters(), lr=1.0)
+for _ in range(200):
+    optimizer.zero_grad()
+    spec, _ = dstft(x)
+    loss = spec.sum(dim=(1, 2)).mean()  # e.g. any loss defined on the spectrogram
+    loss.backward()
+    optimizer.step()
+
+print(dstft.win_length)  # moved away from its initial value of 256.0
+```
+
+See `notebooks/window_optimization.ipynb` and `notebooks/hop_optimization.ipynb`
+for a full walkthrough of what each learnable parameter controls and how to
+read the results.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -110,9 +110,8 @@ for _ in range(200):
 print(dstft.win_length)  # moved away from its initial value of 256.0
 ```
 
-See `notebooks/window_optimization.ipynb` and `notebooks/hop_optimization.ipynb`
-for a full walkthrough of what each learnable parameter controls and how to
-read the results.
+See `notebooks/inverse.ipynb` for a full worked example, including
+reconstructing the signal back from the transform.
 
 ## License
 

--- a/docs/notebooks/inverse.ipynb
+++ b/docs/notebooks/inverse.ipynb
@@ -8,6 +8,12 @@
    ]
   },
   {
+   "id": "a35ada73",
+   "cell_type": "markdown",
+   "source": "[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/maxime-leiber/dstft/blob/main/notebooks/inverse.ipynb)",
+   "metadata": {}
+  },
+  {
    "cell_type": "code",
    "execution_count": 13,
    "metadata": {},

--- a/notebooks/inverse.ipynb
+++ b/notebooks/inverse.ipynb
@@ -8,6 +8,12 @@
    ]
   },
   {
+   "id": "a35ada73",
+   "cell_type": "markdown",
+   "source": "[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/maxime-leiber/dstft/blob/main/notebooks/inverse.ipynb)",
+   "metadata": {}
+  },
+  {
    "cell_type": "code",
    "execution_count": 13,
    "metadata": {},

--- a/tests/test_dstft.py
+++ b/tests/test_dstft.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import math
+
 import pytest
 import torch
 
@@ -305,3 +307,149 @@ def test_fixed_hop_mode_keeps_the_shared_single_row_window() -> None:
     dstft(x)
 
     assert dstft.analysis_window.shape[1] == 1
+
+
+# ---------------------------------------------------------------------------
+# Gradient correctness (torch.autograd.gradcheck)
+# ---------------------------------------------------------------------------
+#
+# gradcheck compares the analytical backward pass against a numerical
+# finite-difference estimate, so it needs float64 and a function whose only
+# input is the tensor under test. DSTFT stores its learnable parameters as
+# registered nn.Parameters, so the checked tensor has to be swapped in via
+# object.__setattr__ (bypassing nn.Module's own parameter bookkeeping)
+# rather than re-wrapped in a fresh nn.Parameter, which would silently
+# detach it from the graph gradcheck is perturbing.
+
+
+def _gradcheck_raw_param(dstft: DSTFT, attr: str, x: torch.Tensor) -> bool:
+    raw = getattr(dstft, attr).clone().detach().requires_grad_(True)
+
+    def func(raw_param: torch.Tensor) -> torch.Tensor:
+        object.__setattr__(dstft, attr, raw_param)
+        spec, _ = dstft(x)
+        return spec
+
+    return torch.autograd.gradcheck(func, (raw,), eps=1e-6, atol=1e-4)
+
+
+def test_gradcheck_win_length_fft_backend() -> None:
+    torch.manual_seed(0)
+    x = torch.randn(1, 128, dtype=torch.float64)
+    dstft = DSTFT(
+        n_fft=32,
+        win_length=24.0,
+        hop_length=8.0,
+        window_mode="constant",
+        hop_mode="fixed",
+    )
+    dstft.initialize(x)
+    dstft.double()
+
+    assert _gradcheck_raw_param(dstft, "_raw_win_length", x)
+
+
+def test_gradcheck_hop_length_fft_backend() -> None:
+    torch.manual_seed(0)
+    x = torch.randn(1, 128, dtype=torch.float64)
+    dstft = DSTFT(
+        n_fft=32, win_length=24.0, hop_length=8.0, window_mode="time", hop_mode="time"
+    )
+    dstft.initialize(x)
+    dstft.double()
+
+    assert _gradcheck_raw_param(dstft, "_raw_hop_length", x)
+
+
+def test_gradcheck_win_length_dft_backend() -> None:
+    torch.manual_seed(0)
+    x = torch.randn(1, 130, dtype=torch.float64)
+    dstft = DSTFT(
+        n_fft=16,
+        win_length=12.0,
+        hop_length=7.0,
+        window_mode="time-frequency",
+        hop_mode="fixed",
+    )
+    dstft.initialize(x)
+    dstft.double()
+
+    assert _gradcheck_raw_param(dstft, "_raw_win_length", x)
+
+
+# ---------------------------------------------------------------------------
+# Numerical parity with torch.stft
+# ---------------------------------------------------------------------------
+#
+# DSTFT's frame-centering convention (frames centered at t_n, with implicit
+# zero-padding for out-of-range samples) differs from torch.stft's frame
+# layout (frames start at n * hop_length, center=False means no padding at
+# all), so the two aren't directly comparable frame-by-frame across a whole
+# signal. To sidestep that, each check isolates a single interior DSTFT
+# frame, floors its own reported center exactly the way DSTFT's forward
+# pass does (idx_floor = floor(t_n), not round(t_n) - these differ whenever
+# hop_length's sigmoid reparameterization lands a hair below an integer),
+# and asks torch.stft to transform only that n_fft-sample segment.
+# Magnitude only, since phase convention (centered vs frame-start-relative)
+# is a deliberate design choice, not something torch.stft shares.
+
+
+@pytest.mark.parametrize("frame_index", [3, 5, 10])
+def test_matches_torch_stft_magnitude_per_frame(frame_index: int) -> None:
+    torch.manual_seed(0)
+    x = torch.randn(1, 512, dtype=torch.float64)
+    n_fft, hop_length, win_length = 64, 16, 64
+
+    dstft = DSTFT(
+        n_fft=n_fft,
+        win_length=float(win_length),
+        hop_length=float(hop_length),
+        window_mode="fixed",
+        hop_mode="fixed",
+    )
+    dstft.initialize(x)
+    dstft.double()
+    _, stft = dstft(x)
+    centers = dstft.frame_centers()
+
+    t_n = math.floor(centers[frame_index].item())
+    start = t_n - n_fft // 2
+    segment = x[:, start : start + n_fft]
+
+    window = torch.hann_window(win_length, periodic=True, dtype=torch.float64)
+    ref = torch.stft(
+        segment,
+        n_fft=n_fft,
+        hop_length=n_fft,
+        win_length=win_length,
+        window=window,
+        center=False,
+        return_complex=True,
+    )
+
+    torch.testing.assert_close(
+        stft[0, :, frame_index].abs(), ref[0, :, 0].abs(), atol=1e-3, rtol=1e-3
+    )
+
+
+# ---------------------------------------------------------------------------
+# Device coverage
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="requires a CUDA device")
+def test_forward_and_backward_on_cuda() -> None:
+    torch.manual_seed(0)
+    device = torch.device("cuda")
+    x = torch.randn(1, 256, device=device)
+    dstft = DSTFT(
+        n_fft=64, win_length=48.0, hop_length=16.0, window_mode="time", hop_mode="time"
+    )
+    dstft.initialize(x)
+
+    spec, _ = dstft(x)
+    assert spec.device.type == "cuda"
+
+    spec.sum().backward()
+    assert dstft._raw_win_length.grad is not None
+    assert dstft._raw_win_length.grad.device.type == "cuda"


### PR DESCRIPTION
## Summary
- `.gitattributes`: mark notebooks `linguist-generated` so GitHub stops reading the repo as ~97% Jupyter Notebook (executed notebooks with stored outputs, needed for ReadTheDocs — not something to strip).
- `notebooks/inverse.ipynb`: "Open in Colab" badge. The two notebooks on PR #17 (still open) will get the same badge once that PR merges, rather than touching it now.
- `README.md`: short gradient-optimization example after the basic usage snippet — verified it actually moves `win_length` before writing it down.
- `tests/test_dstft.py`: `gradcheck` (FFT + DFT backend), per-frame magnitude parity against `torch.stft` (see commit message for why it's per-frame rather than whole-signal — DSTFT's centered framing doesn't align with `torch.stft`'s frame-start convention), and a CUDA forward+backward test (skips cleanly with no GPU).
- `.github/workflows/ci.yml`: test matrix now covers Python 3.12 too.

No changes to `src/dstft/` — purely tests, docs, and CI config.

## Test plan
- [x] `pytest` — 81 passed, 1 skipped (CUDA, no GPU here)
- [x] `pre-commit run` — passes
- [x] `SPHINX_OFFLINE=1 sphinx-build -b html docs  -W --keep-going` — builds clean

---
_Generated by [Claude Code](https://claude.ai/code/session_01KyjjDHc4vpTx6jDv1rWfC7)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Added guidance for gradient-based optimization of DSTFT parameters with PyTorch.
  - Added “Open in Colab” badges to inverse-processing notebooks for easier interactive use.

- **Testing**
  - Expanded validation of DSTFT gradients, numerical consistency with PyTorch STFT, and CUDA execution.
  - Added continuous integration coverage for Python 3.12.

- **Chores**
  - Improved repository handling of generated notebook files.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->