### PR TITLE
Document PyPI installation alongside the existing editable-install docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,35 @@ Gradient-based optimization of DSTFT parameters (example: window length).
 
 ## Installation
 
-### pip/venv
+### From PyPI
+
+For general use, install the published package:
+
+```bash
+pip install dstft
+```
+
+Or with [`uv`](https://github.com/astral-sh/uv):
+
+```bash
+uv pip install dstft
+```
+
+Or in a Conda/Mamba environment (there is no separate conda-forge package;
+`pip install` works the same once the environment is activated):
+
+```bash
+mamba create -n dstft python=3.11 pip
+mamba activate dstft
+pip install dstft
+```
+
+### For development (editable install)
+
+To contribute to `dstft` itself, clone the repository and install in
+editable mode instead — see [Contributing](#contributing) below.
+
+#### pip/venv
 
 Create and activate a virtual environment, then install in editable mode:
 
@@ -39,7 +67,7 @@ pip install -U pip
 pip install -e .
 ```
 
-### Conda/Mamba + uv
+#### Conda/Mamba + uv
 
 Create a new environment:
 

--- a/README.md
+++ b/README.md
@@ -39,6 +39,8 @@ pip install dstft
 Or with [`uv`](https://github.com/astral-sh/uv):
 
 ```bash
+uv venv
+source .venv/bin/activate
 uv pip install dstft
 ```
 

--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -1,11 +1,14 @@
 Getting started
 ===============
 
-Install the package in editable mode:
+Install the package:
 
 .. code-block:: bash
 
-   pip install -e .
+   pip install dstft
+
+See :doc:`installation` for other installation methods (``uv``, Conda/Mamba,
+or an editable install for development).
 
 Quick example:
 

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -1,8 +1,39 @@
 Installation
 ============
 
+From PyPI
+---------
+
+For general use, install the published package:
+
+.. code-block:: bash
+
+   pip install dstft
+
+Or with `uv <https://github.com/astral-sh/uv>`_:
+
+.. code-block:: bash
+
+   uv pip install dstft
+
+Or in a Conda/Mamba environment (there is no separate conda-forge package;
+``pip install`` works the same once the environment is activated):
+
+.. code-block:: bash
+
+   mamba create -n dstft python=3.11 pip
+   mamba activate dstft
+   pip install dstft
+
+
+For development (editable install)
+-----------------------------------
+
+To contribute to ``dstft`` itself, clone the repository and install in
+editable mode instead.
+
 Universal (pip/venv)
---------------------
+~~~~~~~~~~~~~~~~~~~~~
 
 Create and activate a virtual environment, then install in editable mode:
 
@@ -22,7 +53,7 @@ Optional dependencies:
 
 
 Conda/Mamba + uv (recommended)
-------------------------------
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Create a new environment:
 

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -14,6 +14,8 @@ Or with `uv <https://github.com/astral-sh/uv>`_:
 
 .. code-block:: bash
 
+   uv venv
+   source .venv/bin/activate
    uv pip install dstft
 
 Or in a Conda/Mamba environment (there is no separate conda-forge package;


### PR DESCRIPTION
## Summary

- `README.md` (`## Installation`), `docs/installation.rst`, and
  `docs/getting_started.rst` only documented the editable/dev install
  (`pip install -e .` from a clone), which is only relevant for developing
  the package itself.
- `dstft` is now published on PyPI (v3.0.0, published 2026-08-08), so this
  adds a standard user install (`pip install dstft`, `uv pip install dstft`,
  and the Conda/Mamba equivalent) ahead of the existing instructions.
- The previous editable-install content is kept as-is, now grouped under a
  "For development (editable install)" subsection in both `README.md` and
  `docs/installation.rst`.
- `docs/getting_started.rst` now points to `pip install dstft` as the quick
  path, with a link to `installation.rst` for the other methods.

No other `.md`/`.rst` file in the repo referenced `pip install -e .` without
the PyPI alternative (checked via grep across `*.md`/`*.rst`).

## Test plan

- [x] `pre-commit run --files README.md docs/installation.rst
      docs/getting_started.rst` passes.
- [x] `sphinx-build -b html . <out> -W` (warnings-as-errors) builds clean,
      confirming the new/renamed `.rst` headings and the `:doc:`
      cross-reference resolve correctly.
- Doc-only change, no code/behavior affected.

---
Purement informatique (documentation), pas de changement de comportement
dans `src/dstft/`.


---
_Generated by [Claude Code](https://claude.ai/code/session_01KyjjDHc4vpTx6jDv1rWfC7)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified installation instructions for the published package using pip, uv, and Conda/Mamba.
  * Added guidance for editable development setups with pip/venv and Conda/Mamba.
  * Updated getting-started instructions to use the published package and link to alternative installation methods.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->