### PR TITLE
Add CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -34,7 +34,8 @@ pip install -e ".[docs]"
 python -m pytest --cov=dstft --cov-report=term-missing
 ```
 
-CI runs this against Python 3.10, 3.11, and 3.12 — see
+CI runs the same command (plus `--cov-report=xml`, only needed to upload
+coverage to Codecov) against Python 3.10, 3.11, and 3.12 — see
 [`.github/workflows/ci.yml`](.github/workflows/ci.yml).
 
 ## Pre-commit checks
@@ -67,8 +68,9 @@ obvious from the diff or from the code itself.
 
 1. Fork the repository and create a branch for your change.
 2. Make your change, with tests covering new behavior and/or bug fixes.
-3. Run `pytest` and `pre-commit run --all-files` locally; both must pass
-   (CI enforces the same checks).
+3. Run `python -m pytest --cov=dstft --cov-report=term-missing` and
+   `pre-commit run --all-files` locally; both must pass (CI runs the
+   equivalent test and pre-commit-hooks checks).
 4. Open a pull request against `main` describing what changed and why —
    see recently merged PRs for the expected level of detail.
 
@@ -79,6 +81,7 @@ and, where relevant, include a comparison against the previous behavior
 
 ## Reporting bugs or requesting features
 
-Please [open an issue](https://github.com/maxime-leiber/dstft/issues) using
-the issue templates, which list the information that's most useful to
-include.
+Please [open an issue](https://github.com/maxime-leiber/dstft/issues). For a
+bug report, include a minimal reproduction and the expected vs. observed
+behavior; for a feature request, describe the problem it would solve. Also
+include your `dstft`, PyTorch, and Python versions for bug reports.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,84 @@
+# Contributing to dstft
+
+Thanks for your interest in contributing! This document covers how to set up
+a development environment, run the test suite and pre-commit checks, and
+submit a pull request.
+
+## Development setup
+
+Clone the repository and install it in editable mode with the development
+extras:
+
+```bash
+git clone https://github.com/maxime-leiber/dstft.git
+cd dstft
+python -m venv venv
+source venv/bin/activate
+pip install -U pip
+pip install -e ".[dev]"
+```
+
+See the [Installation](README.md#installation) section of the README for
+Conda/Mamba + `uv` alternatives.
+
+To also build the documentation locally, install the `docs` extra as well
+(`pip install -e ".[dev,docs]"` installs both at once):
+
+```bash
+pip install -e ".[docs]"
+```
+
+## Running the test suite
+
+```bash
+python -m pytest --cov=dstft --cov-report=term-missing
+```
+
+CI runs this against Python 3.10, 3.11, and 3.12 — see
+[`.github/workflows/ci.yml`](.github/workflows/ci.yml).
+
+## Pre-commit checks
+
+This repo enforces formatting, linting, `mypy`, and docstring coverage via
+[pre-commit](https://pre-commit.com) (config in
+[`.pre-commit-config.yaml`](.pre-commit-config.yaml)). Install the hooks once
+so they run automatically on `git commit`:
+
+```bash
+pre-commit install
+```
+
+Or run them on demand against the whole repo — this is what the `lint` job
+in CI runs:
+
+```bash
+pre-commit run --all-files
+```
+
+## Commit messages
+
+Commit subject lines are written in the imperative mood and describe what
+the commit does, e.g. `Fix hop_length getting no/incomplete gradient with a
+scalar window_mode`. There is no enforced prefix convention (no
+`feat:`/`fix:`); use the commit body to explain *why* when the reason isn't
+obvious from the diff or from the code itself.
+
+## Submitting a pull request
+
+1. Fork the repository and create a branch for your change.
+2. Make your change, with tests covering new behavior and/or bug fixes.
+3. Run `pytest` and `pre-commit run --all-files` locally; both must pass
+   (CI enforces the same checks).
+4. Open a pull request against `main` describing what changed and why —
+   see recently merged PRs for the expected level of detail.
+
+Changes to `src/dstft/` that alter numerical behavior (new formulas, new
+modes, changed defaults) get extra scrutiny: please explain the motivation
+and, where relevant, include a comparison against the previous behavior
+(e.g. a gradcheck or a `torch.stft` parity check).
+
+## Reporting bugs or requesting features
+
+Please [open an issue](https://github.com/maxime-leiber/dstft/issues) using
+the issue templates, which list the information that's most useful to
+include.

--- a/README.md
+++ b/README.md
@@ -151,7 +151,8 @@ This project is licensed under the terms of the MIT License. See the
 ## Contributing
 
 Contributions are welcome! Please open issues or pull requests for bug fixes,
-improvements, or new features.
+improvements, or new features. See [CONTRIBUTING.md](CONTRIBUTING.md) for the
+development setup, test/pre-commit commands, and PR guidelines.
 
 ## Releasing
 


### PR DESCRIPTION
## Summary

- Adds `CONTRIBUTING.md`: dev install (`pip install -e ".[dev]"`, `[docs]`
  extra), running the test suite (`pytest --cov=dstft`), running/installing
  `pre-commit` hooks (matches what the `lint` CI job runs), the observed
  commit-message convention (imperative subject line, no enforced
  `feat:`/`fix:` prefix — based on the actual history of merged PRs), the PR
  process, and where to report bugs/request features.
- Links to it from the README's existing `## Contributing` section (and
  from the "for development" note added in #27).
- No enforced convention was invented (e.g. no Conventional Commits): the
  doc describes what this repo's commit history actually does.

## Test plan

- [x] `pre-commit run --files CONTRIBUTING.md README.md` passes.
- Doc-only change (community-hygiene file), no code/behavior affected.

---
Purement informatique (fichier de hygiène communautaire), pas de changement
de comportement dans `src/dstft/`.


---
_Generated by [Claude Code](https://claude.ai/code/session_01KyjjDHc4vpTx6jDv1rWfC7)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive contribution guidelines covering development setup, testing, pre-commit checks, commit messages, pull requests, and issue reporting.
  * Updated the README to link to the new contribution guide and summarize key development practices.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->