### PR TITLE
Add SECURITY.md

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,30 @@
+# Security Policy
+
+## Supported Versions
+
+`dstft` is a small, actively maintained research package published on PyPI.
+Only the latest released version receives security updates:
+
+| Version | Supported          |
+| ------- | ------------------ |
+| 3.x     | :white_check_mark: |
+| < 3.0   | :x:                |
+
+## Reporting a Vulnerability
+
+Please **do not** open a public GitHub issue for security vulnerabilities.
+
+Instead, report it privately using one of these channels:
+
+- [GitHub's private vulnerability reporting](https://github.com/maxime-leiber/dstft/security/advisories/new)
+  (Security tab → "Report a vulnerability"), if enabled on this repository.
+- Email 66619209+maxime-leiber@users.noreply.github.com with details of the
+  issue.
+
+Please include, where applicable: the affected version, a minimal
+reproduction, and the potential impact.
+
+There is no formal SLA, but reports will be acknowledged and investigated
+as soon as possible given this is a single-maintainer project. A fix or
+mitigation will be released and, where appropriate, disclosed via a GitHub
+Security Advisory once available.


### PR DESCRIPTION
## Summary

- Adds `SECURITY.md`: directs vulnerability reports away from public
  issues, to either GitHub's private vulnerability reporting
  (`.../security/advisories/new`, if enabled on this repo) or the
  maintainer's email (same GitHub-provided noreply address used as the
  fallback contact in `CODE_OF_CONDUCT.md`, #29).
- Supported versions: only the latest published `3.x` release — matches
  the actual PyPI publish history (v3.0.0 is the only tagged release so
  far).
- Not linked from README/CONTRIBUTING: GitHub auto-detects `SECURITY.md`
  at the repo root and surfaces it in the repo's Security tab and the
  "New issue" flow on its own, so no extra cross-link was added (unlike
  CONTRIBUTING.md/CODE_OF_CONDUCT.md, which aren't auto-surfaced the same
  way).
- Note: GitHub's private vulnerability reporting still needs to be
  enabled in repo settings (Settings → Security → Private vulnerability
  reporting) for that link to actually work; I can't toggle that myself.
  Flagged in the local TODO for Maxime; the email fallback works
  regardless.

## Test plan

- [x] `pre-commit run --files SECURITY.md` passes.
- Doc-only change (community-hygiene file), no code/behavior affected.

---
Purement informatique (fichier de hygiène communautaire), pas de changement
de comportement dans `src/dstft/`.


---
_Generated by [Claude Code](https://claude.ai/code/session_01KyjjDHc4vpTx6jDv1rWfC7)_