### PR TITLE
Add .github/pull_request_template.md

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,23 @@
+## Summary
+
+<!--
+What changed and why. Link the issue/discussion this addresses if there is
+one. For a fix, include the root cause, not just the symptom.
+-->
+
+## Test plan
+
+<!--
+Checklist of what you ran to verify this, e.g.:
+- [ ] `pytest` / `pytest --cov=dstft --cov-report=term-missing`
+- [ ] `pre-commit run --all-files`
+- [ ] `sphinx-build -b html docs docs/_build/html -W --keep-going` (if docs changed)
+- [ ] Manual verification (describe what you checked)
+-->
+
+<!--
+If this PR changes numerical behavior in `src/dstft/` (a new formula, a new
+mode, a changed default, a bug fix that alters output), say so explicitly
+and include a comparison against the previous behavior (e.g. a gradcheck or
+a torch.stft parity check) — see CONTRIBUTING.md.
+-->


### PR DESCRIPTION
## Summary

- Adds `.github/pull_request_template.md` with `## Summary` / `## Test
  plan` sections, matching the format already used consistently across
  merged PRs (#5-#30) — this just makes that convention explicit for
  future contributors instead of leaving it implicit.
- Includes a reminder (as HTML comments, so it doesn't clutter the
  rendered PR body once filled in) to flag PRs that change numerical
  behavior in `src/dstft/` and include a comparison against the previous
  behavior, matching what `CONTRIBUTING.md` (#28) already asks for.
- This PR itself predates the template (GitHub only pre-fills new PR
  bodies from a template already present on the base branch), so its body
  above just follows the same format by hand.

## Test plan

- [x] `pre-commit run --files .github/pull_request_template.md` passes.
- Doc-only change (community-hygiene file), no code/behavior affected.

---
Purement informatique (fichier de hygiène communautaire), pas de changement
de comportement dans `src/dstft/`.


---
_Generated by [Claude Code](https://claude.ai/code/session_01KyjjDHc4vpTx6jDv1rWfC7)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a pull request template with structured sections for change summaries and test plans.
  * Included checklists for automated and manual verification.
  * Added guidance for documenting numerical behavior changes and comparisons with previous behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->