### PR TITLE
Add .github/ISSUE_TEMPLATE/bug_report.md

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,44 @@
+---
+name: Bug report
+about: Report unexpected behavior, an error, or a numerical issue
+title: ""
+labels: bug
+assignees: ""
+---
+
+## Description
+
+A clear description of the bug.
+
+## Reproduction
+
+A minimal, self-contained code snippet that reproduces the issue:
+
+```python
+import torch
+from dstft import DSTFT
+
+# ...
+```
+
+## Expected behavior
+
+What you expected to happen.
+
+## Observed behavior
+
+What actually happened instead — include the full error message/traceback
+if there is one.
+
+## Environment
+
+- `dstft` version:
+- PyTorch version:
+- Python version:
+- OS:
+- Device (CPU/CUDA), if relevant:
+
+## Additional context
+
+Anything else that might be relevant (e.g. whether this only happens with
+a specific `window_mode`/`hop_mode`, a specific signal length, etc.).


### PR DESCRIPTION
## Summary

- Adds `.github/ISSUE_TEMPLATE/bug_report.md`: reproduction (minimal
  code snippet), expected vs. observed behavior, and environment info
  (`dstft`/PyTorch/Python versions, OS, device) — this is exactly what
  `CONTRIBUTING.md` (#28) already tells contributors a bug report should
  include, so the template just makes filling that in easier.
- Applies the existing `bug` label (confirmed it already exists on this
  repo via the GitHub API before referencing it in the template's front
  matter, so it won't silently no-op).

## Test plan

- [x] `pre-commit run --files .github/ISSUE_TEMPLATE/bug_report.md`
      passes.
- [x] Verified the YAML front matter parses (`yaml.safe_load`) — pre-commit's
      `check-yaml` hook doesn't scan `.md` files, so checked this manually.
- Doc-only change (community-hygiene file), no code/behavior affected.

---
Purement informatique (fichier de hygiène communautaire), pas de changement
de comportement dans `src/dstft/`.


---
_Generated by [Claude Code](https://claude.ai/code/session_01KyjjDHc4vpTx6jDv1rWfC7)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a structured bug-report template with prompts for reproduction steps, expected and observed behavior, environment details, and supporting context.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->