### PR TITLE
Add CHANGELOG.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,37 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+This changelog starts from `v3.0.0` (the first version published on PyPI);
+earlier history isn't backfilled.
+
+## [Unreleased]
+
+### Added
+
+- Standard PyPI installation instructions (`pip install dstft`, `uv pip
+  install dstft`, Conda/Mamba) in `README.md` and the docs, alongside the
+  existing editable/dev install.
+- `CITATION.cff` and a landing-page pitch paragraph in `README.md`/docs.
+- Colab badge and an expanded usage example in `README.md`.
+- Tests: gradient-check (`gradcheck`), `torch.stft` parity, and CUDA
+  device tests; CI now also runs on Python 3.12.
+- `CONTRIBUTING.md`, `CODE_OF_CONDUCT.md`, `SECURITY.md`.
+- `.github/pull_request_template.md`, `.github/ISSUE_TEMPLATE/bug_report.md`,
+  `.github/ISSUE_TEMPLATE/feature_request.md`.
+- `.gitattributes` for consistent line endings.
+
+### Changed
+
+- Test coverage raised from 86% to 97% (`_core.py`, `visualization.py`,
+  and `windows.py` are now at 100%).
+
+### Removed
+
+- `overlap_add_wola`: dead code superseded by `overlap_add_dual`, not
+  part of the public API.
+
+[Unreleased]: https://github.com/maxime-leiber/dstft/compare/v3.0.0...HEAD


### PR DESCRIPTION
## Summary

- Adds `CHANGELOG.md` in [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
  format, with an `[Unreleased]` section summarizing everything merged
  since the `v3.0.0` tag (checked via `git log v3.0.0..HEAD`, PRs #24-#33):
  PyPI install docs, `CITATION.cff`, the #25 quick wins (Colab badge,
  gradcheck/`torch.stft`-parity/CUDA tests, CI 3.12), the 86%→97% coverage
  bump (and the `overlap_add_wola` dead-code removal that came with it,
  called out under "Removed" since it's a public-API-visible change even
  though it was unused), and the community-hygiene files from #28-#33.
- Starts the changelog from `v3.0.0` (first PyPI release) rather than
  backfilling the full pre-3.0 history, per the task scope.
- Not linked from `README.md`: none of the other community-hygiene docs
  added recently (`CONTRIBUTING.md`, `CODE_OF_CONDUCT.md`, `SECURITY.md`)
  needed a change here either, and `CHANGELOG.md` is conventionally found
  by its standard root filename rather than a README pointer.

## Test plan

- [x] `pre-commit run --files CHANGELOG.md` passes.
- Doc-only change (community-hygiene file), no code/behavior affected.

---
Purement informatique (fichier de hygiène communautaire), pas de changement
de comportement dans `src/dstft/`.


---
_Generated by [Claude Code](https://claude.ai/code/session_01KyjjDHc4vpTx6jDv1rWfC7)_