### PR TITLE
Add a CPU micro-benchmark of DSTFT vs torch.stft

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,24 +146,30 @@ reconstructing the signal back from the transform.
 ## Benchmark: DSTFT vs. `torch.stft`
 
 `DSTFT` trades speed and memory for learnable parameters. For a sense of the
-overhead, `scripts/benchmark_vs_torch_stft.py` compares `DSTFT` in its
-cheapest, non-learnable configuration (`window_mode="fixed"`,
-`hop_mode="fixed"`) against `torch.stft` with equivalent parameters
-(`n_fft=1024`, `hop_length=256`, Hann window, batch size 8). Measured on CPU
-(PyTorch 2.13); numbers vary by machine and are meant to convey order of
-magnitude, not precise guarantees.
+overhead, `scripts/benchmark_vs_torch_stft.py` compares `DSTFT`'s complete
+`forward()` API, in its cheapest non-learnable configuration
+(`window_mode="fixed"`, `hop_mode="fixed"`), against raw `torch.stft` with
+equivalent parameters (`n_fft=1024`, `hop_length=256`, Hann window, batch
+size 8). This isn't an equal-amount-of-work comparison: `DSTFT.forward()`
+always computes and returns both the magnitude spectrogram and the complex
+transform, while `torch.stft` only computes the latter, so part of the gap
+below is genuinely more output, not pure overhead. Measured on CPU (PyTorch
+2.13); numbers vary by machine and are meant to convey order of magnitude,
+not precise guarantees.
 
-| Signal length | `torch.stft` | `DSTFT` forward | `DSTFT` forward+backward |
+| Signal length | `torch.stft` (raw) | `DSTFT` `forward()` | `DSTFT` forward+backward |
 | --- | ---: | ---: | ---: |
 | 1s @16kHz | 2.2 ms | 9.1 ms | 14.1 ms |
 | 5s @16kHz | 9.0 ms | 37.4 ms | 63.9 ms |
 | 30s @16kHz | 43.3 ms | 380.3 ms | 779.7 ms |
 
 (one representative run; see the script's docstring for exact parameters).
-`DSTFT`'s forward pass is roughly 4-9x slower than `torch.stft` and uses
-about 3x the memory (measured via `torch.profiler`, sum of per-op CPU
-allocations for a 5s signal: ~45 MB for `torch.stft` vs. ~135 MB for
-`DSTFT`). This is the cost of the extra machinery needed for a
+`DSTFT`'s forward pass is roughly 4-9x slower than raw `torch.stft` and
+shows about 3x the cumulative positive per-op CPU allocations reported by
+`torch.profiler` for a 5s signal (~45 MB for `torch.stft` vs. ~135 MB for
+`DSTFT` — this is allocator-pressure activity, not a peak-live-memory
+figure; `torch.profiler` doesn't expose a single peak-memory number). This
+reflects both the extra output and the machinery needed for a
 window/hop-length-independent, differentiable formulation — `torch.stft` is
 a single fused, highly optimized native op with no such flexibility. Run
 the script yourself (`python scripts/benchmark_vs_torch_stft.py`) to

--- a/README.md
+++ b/README.md
@@ -143,6 +143,32 @@ print(dstft.win_length)  # moved away from its initial value of 256.0
 See `notebooks/inverse.ipynb` for a full worked example, including
 reconstructing the signal back from the transform.
 
+## Benchmark: DSTFT vs. `torch.stft`
+
+`DSTFT` trades speed and memory for learnable parameters. For a sense of the
+overhead, `scripts/benchmark_vs_torch_stft.py` compares `DSTFT` in its
+cheapest, non-learnable configuration (`window_mode="fixed"`,
+`hop_mode="fixed"`) against `torch.stft` with equivalent parameters
+(`n_fft=1024`, `hop_length=256`, Hann window, batch size 8). Measured on CPU
+(PyTorch 2.13); numbers vary by machine and are meant to convey order of
+magnitude, not precise guarantees.
+
+| Signal length | `torch.stft` | `DSTFT` forward | `DSTFT` forward+backward |
+| --- | ---: | ---: | ---: |
+| 1s @16kHz | 2.2 ms | 9.1 ms | 14.1 ms |
+| 5s @16kHz | 9.0 ms | 37.4 ms | 63.9 ms |
+| 30s @16kHz | 43.3 ms | 380.3 ms | 779.7 ms |
+
+(one representative run; see the script's docstring for exact parameters).
+`DSTFT`'s forward pass is roughly 4-9x slower than `torch.stft` and uses
+about 3x the memory (measured via `torch.profiler`, sum of per-op CPU
+allocations for a 5s signal: ~45 MB for `torch.stft` vs. ~135 MB for
+`DSTFT`). This is the cost of the extra machinery needed for a
+window/hop-length-independent, differentiable formulation — `torch.stft` is
+a single fused, highly optimized native op with no such flexibility. Run
+the script yourself (`python scripts/benchmark_vs_torch_stft.py`) to
+reproduce these numbers on your own hardware.
+
 ## License
 
 This project is licensed under the terms of the MIT License. See the

--- a/scripts/benchmark_vs_torch_stft.py
+++ b/scripts/benchmark_vs_torch_stft.py
@@ -1,11 +1,20 @@
 """Micro-benchmark: DSTFT vs. torch.stft, CPU, forward speed and memory.
 
-Compares DSTFT (window_mode="fixed", hop_mode="fixed" — its cheapest,
-non-learnable configuration, closest to what torch.stft computes) against
-torch.stft with equivalent parameters (same n_fft, hop_length, Hann window).
-Also times a DSTFT forward+backward pass (window_mode="constant", learnable
-win_length) as a reference for the actual training-loop cost, since that's
-what torch.stft cannot do at all.
+Compares DSTFT's complete forward() API (window_mode="fixed",
+hop_mode="fixed" — its cheapest, non-learnable configuration) against raw
+torch.stft with equivalent parameters (same n_fft, hop_length, Hann
+window). This is not an apples-to-apples "same amount of work" comparison:
+DSTFT.forward() always computes and returns both the magnitude spectrogram
+and the complex transform, while torch.stft only computes the latter, so
+part of the gap reflects genuinely more output being produced, not pure
+overhead. Also times a DSTFT forward+backward pass (window_mode="constant",
+learnable win_length) as a reference for the actual training-loop cost,
+since that's what torch.stft cannot do at all.
+
+The memory figures report cumulative positive per-op CPU allocation
+activity from torch.profiler (profile_memory=True), summed across
+key_averages() — this is a proxy for allocator pressure, not peak live
+memory: PyTorch's profiler does not expose a single peak-memory figure.
 
 Run with: python scripts/benchmark_vs_torch_stft.py
 """
@@ -104,7 +113,9 @@ def run_memory() -> None:
 
     print()
     print(
-        "Forward-pass CPU memory (sum of positive per-op allocations, torch.profiler):"
+        "Forward-pass cumulative positive per-op CPU allocations, torch.profiler "
+        "(allocator-pressure proxy, NOT peak live memory — torch.profiler doesn't "
+        "expose a single peak-memory figure):"
     )
     for name, fn in [
         ("torch.stft", lambda: torch_stft_forward(x, hann)),
@@ -115,7 +126,7 @@ def run_memory() -> None:
             profile(activities=[ProfilerActivity.CPU], profile_memory=True) as prof,
         ):
             fn()
-        total_kib = (
+        cumulative_alloc_kib = (
             sum(
                 evt.cpu_memory_usage
                 for evt in prof.key_averages()
@@ -123,7 +134,7 @@ def run_memory() -> None:
             )
             / 1024
         )
-        print(f"  {name:22s} {total_kib:10.1f} KiB")
+        print(f"  {name:22s} {cumulative_alloc_kib:10.1f} KiB")
 
 
 if __name__ == "__main__":

--- a/scripts/benchmark_vs_torch_stft.py
+++ b/scripts/benchmark_vs_torch_stft.py
@@ -1,0 +1,135 @@
+"""Micro-benchmark: DSTFT vs. torch.stft, CPU, forward speed and memory.
+
+Compares DSTFT (window_mode="fixed", hop_mode="fixed" — its cheapest,
+non-learnable configuration, closest to what torch.stft computes) against
+torch.stft with equivalent parameters (same n_fft, hop_length, Hann window).
+Also times a DSTFT forward+backward pass (window_mode="constant", learnable
+win_length) as a reference for the actual training-loop cost, since that's
+what torch.stft cannot do at all.
+
+Run with: python scripts/benchmark_vs_torch_stft.py
+"""
+
+from __future__ import annotations
+
+import torch
+import torch.utils.benchmark as torch_benchmark
+from torch.profiler import ProfilerActivity, profile
+
+from dstft import DSTFT
+
+
+N_FFT = 1024
+HOP_LENGTH = 256
+BATCH_SIZE = 8
+SIGNAL_LENGTHS = {
+    "1s @16kHz (16,000 samples)": 16_000,
+    "5s @16kHz (80,000 samples)": 80_000,
+    "30s @16kHz (480,000 samples)": 480_000,
+}
+
+
+def torch_stft_forward(x: torch.Tensor, window: torch.Tensor) -> torch.Tensor:
+    return torch.stft(
+        x,
+        n_fft=N_FFT,
+        hop_length=HOP_LENGTH,
+        window=window,
+        return_complex=True,
+        center=True,
+    )
+
+
+def make_dstft(x: torch.Tensor, *, learnable: bool) -> DSTFT:
+    model = DSTFT(
+        n_fft=N_FFT,
+        hop_length=float(HOP_LENGTH),
+        win_length=float(N_FFT),
+        window_mode="constant" if learnable else "fixed",
+        hop_mode="fixed",
+    )
+    model.initialize(x)
+    return model
+
+
+def run_timing() -> None:
+    header = (
+        f"{'signal length':32s} {'torch.stft (ms)':>16s} "
+        f"{'DSTFT fwd (ms)':>16s} {'DSTFT fwd+bwd (ms)':>20s}"
+    )
+    print(header)
+    print("-" * len(header))
+    for label, sig_len in SIGNAL_LENGTHS.items():
+        x = torch.randn(BATCH_SIZE, sig_len)
+        hann = torch.hann_window(N_FFT)
+
+        t_stft = torch_benchmark.Timer(
+            stmt="torch_stft_forward(x, hann)",
+            globals={"torch_stft_forward": torch_stft_forward, "x": x, "hann": hann},
+        ).blocked_autorange(min_run_time=1.0)
+
+        dstft_fixed = make_dstft(x, learnable=False)
+        with torch.no_grad():
+            t_dstft_fwd = torch_benchmark.Timer(
+                stmt="dstft_fixed(x)",
+                globals={"dstft_fixed": dstft_fixed, "x": x},
+            ).blocked_autorange(min_run_time=1.0)
+
+        dstft_learnable = make_dstft(x, learnable=True)
+
+        def fwd_bwd(
+            dstft_learnable: DSTFT = dstft_learnable, x: torch.Tensor = x
+        ) -> None:
+            spec, _ = dstft_learnable(x)
+            spec.sum().backward()
+            dstft_learnable._raw_win_length.grad = None
+
+        t_dstft_fwd_bwd = torch_benchmark.Timer(
+            stmt="fwd_bwd()",
+            globals={"fwd_bwd": fwd_bwd},
+        ).blocked_autorange(min_run_time=1.0)
+
+        print(
+            f"{label:32s} {t_stft.mean * 1e3:16.2f} "
+            f"{t_dstft_fwd.mean * 1e3:16.2f} {t_dstft_fwd_bwd.mean * 1e3:20.2f}"
+        )
+
+
+def run_memory() -> None:
+    # Representative mid-size signal; memory profiling is more about relative
+    # order of magnitude than a number that needs many signal lengths.
+    x = torch.randn(BATCH_SIZE, SIGNAL_LENGTHS["5s @16kHz (80,000 samples)"])
+    hann = torch.hann_window(N_FFT)
+    dstft_fixed = make_dstft(x, learnable=False)
+
+    print()
+    print(
+        "Forward-pass CPU memory (sum of positive per-op allocations, torch.profiler):"
+    )
+    for name, fn in [
+        ("torch.stft", lambda: torch_stft_forward(x, hann)),
+        ("DSTFT (fixed mode)", lambda: dstft_fixed(x)),
+    ]:
+        with (
+            torch.no_grad(),
+            profile(activities=[ProfilerActivity.CPU], profile_memory=True) as prof,
+        ):
+            fn()
+        total_kib = (
+            sum(
+                evt.cpu_memory_usage
+                for evt in prof.key_averages()
+                if evt.cpu_memory_usage > 0
+            )
+            / 1024
+        )
+        print(f"  {name:22s} {total_kib:10.1f} KiB")
+
+
+if __name__ == "__main__":
+    print(
+        f"PyTorch {torch.__version__}, CPU, batch_size={BATCH_SIZE}, "
+        f"n_fft={N_FFT}, hop_length={HOP_LENGTH}\n"
+    )
+    run_timing()
+    run_memory()


### PR DESCRIPTION
## Summary

Nightly-agent task #16.

- Adds `scripts/benchmark_vs_torch_stft.py`: times `DSTFT` in its cheapest
  non-learnable configuration (`window_mode="fixed"`, `hop_mode="fixed"`)
  against `torch.stft` with equivalent parameters (same `n_fft`,
  `hop_length`, Hann window), across three realistic signal lengths (1s,
  5s, 30s @16kHz, batch size 8). Also times a `DSTFT` forward+backward
  pass (learnable `win_length`) as a training-loop reference, and profiles
  per-op CPU memory via `torch.profiler` for a representative signal.
- Adds a "Benchmark: DSTFT vs. `torch.stft`" section to `README.md` with
  results from one measured run on this machine (PyTorch 2.13, CPU):
  `DSTFT`'s forward pass runs ~4-9x slower than `torch.stft` and uses
  ~3x the memory — the expected cost of the extra machinery its
  learnable, window/hop-length-independent formulation needs, vs.
  `torch.stft`'s single fused native op. Numbers are explicitly framed as
  order-of-magnitude/machine-dependent, with the script provided so
  anyone can reproduce them.
- No `src/dstft/` changes — this only adds a script and documents its
  output, so (per the autonomy rules) I'm merging it myself once CI is
  green and CodeRabbit is clean.

## Test plan

- [x] `python scripts/benchmark_vs_torch_stft.py` — ran it for real
      (twice, to sanity-check run-to-run variance) rather than fabricating
      numbers; the README table uses one specific run's exact output.
- [x] `pytest` — 115 passed, 1 skipped (unchanged; this PR adds no tests
      since it doesn't touch `src/dstft/`)
- [x] `pre-commit run --files README.md scripts/benchmark_vs_torch_stft.py`
      — ruff, ruff-format, mypy, interrogate all pass

---
Purement informatique (script de benchmark + doc de ses résultats), pas de
changement de comportement dans `src/dstft/`.


---
_Generated by [Claude Code](https://claude.ai/code/session_01KyjjDHc4vpTx6jDv1rWfC7)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added benchmark results comparing DSTFT and `torch.stft`, including CPU performance, memory usage, tested configurations, and reproduction instructions.

* **Chores**
  * Added a standalone benchmarking tool to measure forward latency, learnable-window training performance, and memory allocations across signal lengths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->