### PR TITLE
Add a minimal .aider.conf.yml

### DIFF
--- a/.aider.conf.yml
+++ b/.aider.conf.yml
@@ -1,0 +1,10 @@
+# Minimal aider (https://aider.chat) configuration for this repo.
+# See https://aider.chat/docs/config/aider_conf.html for the full option list.
+
+# Contributions go through PRs (see CONTRIBUTING.md); let the author review
+# and commit changes explicitly rather than having aider auto-commit them.
+auto-commits: false
+
+# Hook aider's built-in test/lint commands into what this repo already uses.
+test-cmd: pytest
+lint-cmd: pre-commit run --files

--- a/README.md
+++ b/README.md
@@ -188,6 +188,10 @@ development setup, test/pre-commit commands, and PR guidelines. Everyone
 participating is expected to follow the
 [Code of Conduct](CODE_OF_CONDUCT.md).
 
+If you use [aider](https://aider.chat) to contribute, this repo ships a
+minimal [`.aider.conf.yml`](.aider.conf.yml) (no auto-commits, wired to
+`pytest`/`pre-commit`) that's picked up automatically.
+
 ## Releasing
 
 The package version is derived automatically from git tags (via


### PR DESCRIPTION
## Summary

Nightly-agent task #19 (low priority, last in the queue).

- Adds `.aider.conf.yml`: `auto-commits: false` (contributions go through
  PRs per `CONTRIBUTING.md`, so this leaves committing to the author
  explicitly rather than having aider do it), plus `test-cmd: pytest` and
  `lint-cmd: pre-commit run --files` wired to what this repo already uses.
- Verified the option names against the actual `aider` CLI (`aider
  --help`, installed in a temp venv) rather than guessing — `--auto-commits`,
  `--test-cmd`, `--lint-cmd` are all real options.
- Short mention added to `README.md`'s Contributing section pointing at
  the file.
- No `src/dstft/` changes — self-mergeable per the autonomy rules.

## Test plan

- [x] `pre-commit run --files .aider.conf.yml README.md` — passes
      (`check-yaml` also validates the new file's syntax)
- [x] Verified `.aider.conf.yml` parses (`yaml.safe_load`) and its keys
      match real `aider` CLI options
- Doc/config-only change, no code/behavior affected.

---
Purement informatique (config d'un outil de dev + mention doc), pas de
changement de comportement dans `src/dstft/`.


---
_Generated by [Claude Code](https://claude.ai/code/session_01KyjjDHc4vpTx6jDv1rWfC7)_