### PR TITLE
Fix overlap_add_dual raising RuntimeError instead of ValueError on a frame-count mismatch

### DIFF
--- a/src/dstft/_core.py
+++ b/src/dstft/_core.py
@@ -163,9 +163,11 @@ def overlap_add_dual(
         raise ValueError("analysis_window last dimension must match n_fft")
 
     win = win.to(device=frames.device, dtype=frames.dtype)
-    if win.shape[0] == 1:
+    if win.shape[0] != 1:
+        raise ValueError("analysis_window leading dimension must be 1")
+    if win.shape[1] == 1:
         win = win.expand(1, num_frames, n_fft)
-    elif win.shape[0] != num_frames:
+    elif win.shape[1] != num_frames:
         raise ValueError("analysis_window frames dimension must be 1 or match frames")
 
     idx_floor = frame_positions.floor().to(torch.int64)

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -108,15 +108,27 @@ def test_overlap_add_dual_rejects_window_n_fft_mismatch() -> None:
         )
 
 
+def test_overlap_add_dual_rejects_invalid_leading_dim() -> None:
+    with pytest.raises(ValueError, match="leading dimension must be 1"):
+        _core.overlap_add_dual(
+            frames=_frames(frames=3),
+            frame_positions=_positions(frames=3),
+            analysis_window=torch.ones(2, 3, 8),  # leading dim 2 != 1
+            signal_length=16,
+            eps=1e-8,
+        )
+
+
 def test_overlap_add_dual_rejects_window_frame_count_mismatch() -> None:
-    # Leading dim must be 1 (broadcast) or match num_frames; 2 is neither
-    # (with num_frames=3). See PR description for a related edge case this
-    # ValueError doesn't cover.
+    # Regression test: shape[0]==1 (valid leading dim) but shape[1] (the
+    # actual frames axis) is neither 1 nor num_frames used to fall through
+    # to `.expand()` and raise RuntimeError instead of this ValueError
+    # (see TODO.md [+coverage-95] / PR #26's description).
     with pytest.raises(ValueError, match="frames dimension must be 1 or match frames"):
         _core.overlap_add_dual(
             frames=_frames(frames=3),
             frame_positions=_positions(frames=3),
-            analysis_window=torch.ones(2, 3, 8),  # leading dim 2 != 1 and != 3
+            analysis_window=torch.ones(1, 2, 8),  # frames dim 2 != 1 and != 3
             signal_length=16,
             eps=1e-8,
         )


### PR DESCRIPTION
## Summary

Fixes the bug found (but deliberately left undone) during the PR #26
coverage push and documented in the local TODO — Maxime asked me to fix
it now.

**Root cause:** `overlap_add_dual`'s shape validation checked
`win.shape[0]` (the leading pseudo-batch dim, which is always `1` by
construction — either from `analysis_window.unsqueeze(0)` on a 2D input,
or `windows.py`'s own convention for a 3D one) instead of `win.shape[1]`
(the actual per-frame axis: `1` for a shared window, or `num_frames` for a
per-frame one). Since `shape[0] == 1` unconditionally took the
`.expand(1, num_frames, n_fft)` branch, a real frames-axis mismatch (e.g.
shape `(1, 2, n_fft)` with `num_frames=3`) fell through to `.expand()`,
which raised PyTorch's own `RuntimeError` instead of the function's
documented `ValueError`.

**Fix:** validate `shape[0] == 1` explicitly (its own `ValueError`), and
move the broadcast-or-match check to `shape[1]`. No current caller passes
a mismatched shape — this was a latent bug on already-invalid input, not
something any existing code path hits — so this only changes what error
you get when you *do* pass a malformed `analysis_window`: a clear
`ValueError` instead of an opaque `RuntimeError` from inside `.expand()`.
Nothing about valid-input behavior changes.

**Tests:** split the old
`test_overlap_add_dual_rejects_window_frame_count_mismatch` (which
happened to also trip the `shape[0]` check, masking the real gap — its
own comment said as much) into a dedicated leading-dim test and a
frame-count-mismatch regression test that reproduces the exact original
bug.

## Test plan

- [x] `pytest tests/test_core.py -k overlap_add_dual` — 14 passed,
      including the new/fixed tests
- [x] `pytest` (full suite) — 116 passed, 1 skipped
- [x] `pre-commit run --files src/dstft/_core.py tests/test_core.py` —
      ruff, ruff-format, mypy, interrogate all pass
- [x] Manually verified: both invalid shapes now raise `ValueError` with
      the right message, and both valid shape conventions (shared
      `[1,1,n_fft]` and per-frame `[1,num_frames,n_fft]` windows) still
      produce correct output
- [ ] Human review — this changes error-handling behavior in
      `src/dstft/`'s numeric-path code, please review before merging


---
_Generated by [Claude Code](https://claude.ai/code/session_01KyjjDHc4vpTx6jDv1rWfC7)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation for analysis windows used in overlap-add processing.
  * Invalid window dimensions now produce a clear validation error instead of an internal runtime failure.
  * Two-dimensional analysis windows continue to work as expected.

* **Tests**
  * Added coverage for invalid window shapes and frame-count mismatches.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->