### PR TITLE
Add missing docstrings to private helpers and CG-solver closures

### DIFF
--- a/src/dstft/_core.py
+++ b/src/dstft/_core.py
@@ -15,6 +15,16 @@ _DFT_TWIDDLE_CACHE: dict[tuple[int, int, torch.device, torch.dtype], torch.Tenso
 def _get_rfft_m(
     *, freq_bins: int, device: torch.device, dtype: torch.dtype
 ) -> torch.Tensor:
+    """Return the cached frequency-bin index vector `m = [0, 1, ..., freq_bins - 1]`.
+
+    Args:
+        freq_bins: Number of frequency bins.
+        device: Device to place the tensor on.
+        dtype: Floating-point dtype for the tensor.
+
+    Returns:
+        A 1D tensor of shape `[freq_bins]`, cached per `(freq_bins, device, dtype)`.
+    """
     key = (freq_bins, device, dtype)
     cached = _FFT_FORWARD_CACHE.get(key)
     if cached is None:
@@ -30,6 +40,18 @@ def _get_dft_twiddle(
     device: torch.device,
     dtype: torch.dtype,
 ) -> torch.Tensor:
+    """Return the cached DFT twiddle-factor matrix `exp(-2j*pi*m*k/n_fft)`.
+
+    Args:
+        n_fft: FFT size (number of time samples per frame).
+        freq_bins: Number of frequency bins.
+        device: Device to place the tensor on.
+        dtype: Floating-point dtype used to build the complex exponential.
+
+    Returns:
+        A complex tensor of shape `[freq_bins, n_fft]`, cached per
+        `(n_fft, freq_bins, device, dtype)`.
+    """
     key = (n_fft, freq_bins, device, dtype)
     cached = _DFT_TWIDDLE_CACHE.get(key)
     if cached is None:

--- a/src/dstft/dstft.py
+++ b/src/dstft/dstft.py
@@ -553,13 +553,17 @@ class DSTFT(nn.Module):
     def _inverse_dft_exact(
         self, stft: torch.Tensor
     ) -> torch.Tensor:  # pragma: no cover
-        """Exact DFT-backend inverse via a full Gram-operator CG solve (unreachable scaffolding).
+        """Disabled placeholder for an exact DFT-backend inverse via a Gram-operator CG solve.
+
+        Not wired into ``inverse()``'s method dispatch and currently unreachable:
+        always raises before doing any work, while the adjoint/Gram operator this
+        would rely on is being validated.
 
         Args:
             stft: Complex STFT tensor of shape ``[batch, freq_bins, frames]``.
 
-        Returns:
-            The reconstructed real time-domain signal.
+        Raises:
+            NotImplementedError: Always, until this is wired in and enabled.
         """
         # Not wired into inverse()'s method dispatch yet (kept as scaffolding
         # for a future exact DFT-backend inverse); unreachable until then.
@@ -737,7 +741,13 @@ class DSTFT(nn.Module):
     def _effective_win_length(
         self, *, device: torch.device, dtype: torch.dtype
     ) -> torch.Tensor:
-        """Map the raw (unconstrained) window-length parameter into `[win_length_min, n_fft]`.
+        """Map the raw (unconstrained) window-length parameter into `[_default_win_length_min, n_fft]`.
+
+        Note this lower bound is `_default_win_length_min`, not the public
+        `win_length_min` attribute: when the constructor's `win_length_min`
+        argument is omitted, `_default_win_length_min` falls back to the
+        constructor's (fixed) initial hop length rather than to
+        `win_length_min`'s own default (`max(1, n_fft // 100)`).
 
         Args:
             device: Device to place the result on.

--- a/src/dstft/dstft.py
+++ b/src/dstft/dstft.py
@@ -478,6 +478,7 @@ class DSTFT(nn.Module):
             ).real
 
             def apply_a(x_time: torch.Tensor) -> torch.Tensor:
+                """Apply the forward DFT-backend analysis operator ``A`` to a time signal."""
                 frames_x, idx_floor_x, idx_frac_x = _core.unfold_floor_frac(
                     x=x_time,
                     frame_positions=frame_positions,
@@ -492,6 +493,7 @@ class DSTFT(nn.Module):
                 )
 
             def apply_at(y_stft: torch.Tensor) -> torch.Tensor:
+                """Apply the adjoint operator ``A*`` to an STFT, returning a real time signal."""
                 return _core.adstft_dft_adjoint(
                     stft=y_stft,
                     analysis_window=analysis_window.to(y_stft.dtype),
@@ -501,10 +503,12 @@ class DSTFT(nn.Module):
                 ).real
 
             def apply_mat(x_time: torch.Tensor) -> torch.Tensor:
+                """Apply the regularized Gram operator ``A* A + λI`` used by the CG solve."""
                 x_stft = apply_a(x_time)
                 return apply_at(x_stft) + (float(cg_lambda) * x_time)
 
             def precond(r: torch.Tensor) -> torch.Tensor:
+                """Apply the diagonal (WOLA-denominator) preconditioner to a CG residual."""
                 return r / den[None, :]
 
             x0 = torch.zeros_like(b)
@@ -549,6 +553,14 @@ class DSTFT(nn.Module):
     def _inverse_dft_exact(
         self, stft: torch.Tensor
     ) -> torch.Tensor:  # pragma: no cover
+        """Exact DFT-backend inverse via a full Gram-operator CG solve (unreachable scaffolding).
+
+        Args:
+            stft: Complex STFT tensor of shape ``[batch, freq_bins, frames]``.
+
+        Returns:
+            The reconstructed real time-domain signal.
+        """
         # Not wired into inverse()'s method dispatch yet (kept as scaffolding
         # for a future exact DFT-backend inverse); unreachable until then.
         raise NotImplementedError(
@@ -584,6 +596,7 @@ class DSTFT(nn.Module):
             )
 
         def apply_gram(x_flat: torch.Tensor) -> torch.Tensor:
+            """Apply the full Gram operator ``A* A`` to a flattened time signal."""
             x = x_flat.view(-1, signal_length)
             frames, _, _ = _core.unfold_floor_frac(
                 x=x,
@@ -674,6 +687,13 @@ class DSTFT(nn.Module):
         )
 
     def _validate_parameter_shapes(self) -> None:
+        """Validate that the raw win_length/hop_length tensors have broadcastable shapes.
+
+        Raises:
+            RuntimeError: If `win_length` or `hop_length` has the wrong number of
+                dimensions, or a size that is neither 1 nor the expected
+                broadcast target (`freq_bins`/`frames`).
+        """
         if self._raw_win_length.ndim != 2:
             raise RuntimeError("win_length must be 2D")
         if self._num_frames is None:
@@ -717,6 +737,15 @@ class DSTFT(nn.Module):
     def _effective_win_length(
         self, *, device: torch.device, dtype: torch.dtype
     ) -> torch.Tensor:
+        """Map the raw (unconstrained) window-length parameter into `[win_length_min, n_fft]`.
+
+        Args:
+            device: Device to place the result on.
+            dtype: Floating-point dtype for the result.
+
+        Returns:
+            The constrained window length, via a sigmoid squashing of `_raw_win_length`.
+        """
         raw = self._raw_win_length.to(device=device, dtype=dtype)
         win_min = torch.tensor(
             float(self._default_win_length_min), device=device, dtype=dtype
@@ -727,6 +756,15 @@ class DSTFT(nn.Module):
     def _effective_hop_length(
         self, *, device: torch.device, dtype: torch.dtype
     ) -> torch.Tensor:
+        """Map the raw (unconstrained) hop-length parameter into `[hop_length_min, hop_length_max]`.
+
+        Args:
+            device: Device to place the result on.
+            dtype: Floating-point dtype for the result.
+
+        Returns:
+            The constrained hop length, via a sigmoid squashing of `_raw_hop_length`.
+        """
         raw = self._raw_hop_length.to(device=device, dtype=dtype)
         hop_min = torch.tensor(float(self.hop_length_min), device=device, dtype=dtype)
         hop_max = torch.tensor(float(self.hop_length_max), device=device, dtype=dtype)
@@ -769,6 +807,19 @@ class DSTFT(nn.Module):
         return plot_win_lengths(self.win_length, **kwargs)
 
     def _resolve_window(self, window: WindowSpec) -> WindowFn:
+        """Resolve a window spec (name or callable) into a window-generating callable.
+
+        Args:
+            window: Either a known window-name string (currently only `"hann"`)
+                or a callable already matching the `WindowFn` protocol.
+
+        Returns:
+            The resolved `WindowFn` callable.
+
+        Raises:
+            ValueError: If `window` is a string that names an unknown window.
+            TypeError: If `window` is neither a string nor callable.
+        """
         if isinstance(window, str):
             if window == "hann":
                 return windows.hann_window


### PR DESCRIPTION
## Summary

Finishes the "task 18" docstring gap left over from PR #37 (which fixed the missing return-type annotations but skipped the docstring part). An AST audit confirmed these 12 functions/closures had no docstring at all:

- `dstft.py`: `_inverse_dft_exact`, `_validate_parameter_shapes`, `_effective_win_length`, `_effective_hop_length`, `_resolve_window`, and the CG-solver closures `apply_a`, `apply_at`, `apply_mat`, `precond` (inside `inverse()`), `apply_gram` (inside `_inverse_dft_exact`)
- `_core.py`: `_get_rfft_m`, `_get_dft_twiddle`

All 12 now have a Google-style docstring: a one-line summary, plus `Args`/`Returns`/`Raises` where the signature isn't self-evident (small internal CG closures get a one-liner only, per the existing convention in this repo).

No behavior change — documentation and type annotations only, no formulas or numeric logic touched.

## Test plan

- [x] AST check: all 12 targets now have `ast.get_docstring(...) is not None`
- [x] `mypy` (strict): `Success: no issues found in 5 source files`
- [x] `pytest`: 116 passed, 1 skipped (unchanged)
- [x] `pre-commit run` on both changed files: all hooks pass, including `interrogate` (docstring coverage)

---
_Generated by [Claude Code](https://claude.ai/code/session_01KyjjDHc4vpTx6jDv1rWfC7)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Expanded documentation for DSTFT utilities and inverse-processing methods.
  * Added details about parameters, return values, tensor shapes, validation behavior, and caching.
  * Clarified window-length and hop-length transformations.
  * Improved descriptions of input and output expectations for more consistent usage.
  * No functional behavior or public interfaces changed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->